### PR TITLE
chore: use @dcm-project/maintainers team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dcm-project/maintainers


### PR DESCRIPTION
Replaces individual GitHub usernames with the `@dcm-project/maintainers` team.

Maintainers team: https://github.com/orgs/dcm-project/teams/maintainers

Jira: [FLPATH-4458](https://redhat.atlassian.net/browse/FLPATH-4458)