### PR TITLE
dd2: expand the DCM validation corpus

### DIFF
--- a/dav/use-cases/compute/idempotent-reconvergence.yaml
+++ b/dav/use-cases/compute/idempotent-reconvergence.yaml
@@ -1,0 +1,63 @@
+uuid: uc-pipeline-idempotent-001
+handle: compute/idempotent-reconvergence
+scenario:
+  description: An application team re-applies an unchanged intent to an already-realized
+    resource. The system must recognize that the intent matches the current realized
+    state and produce a no-op — no new dispatch, no new provider calls, no duplicate
+    resources. This validates the idempotency guarantee that is critical for safe reconvergence
+    and rehydration.
+  actor:
+    persona: application-team-member
+    profile: standard
+  intent: Re-apply unchanged intent and verify no-op reconvergence
+  success_criteria:
+  - Re-applied intent is accepted and processed through the pipeline
+  - System detects that realized state already matches the intent
+  - No new provider dispatch occurs (no-op)
+  - No duplicate resources are created
+  - The no-op decision and its rationale are recorded in the audit trail
+  - Resource UUIDs remain stable (no reassignment)
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: single_no_deps
+    policy_complexity: single_validation
+    provider_landscape: single_eligible
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: intent compared against realized state
+  - domain: policy
+    interaction: validation policy evaluates the re-applied request
+  - domain: audit
+    interaction: no-op decision recorded with rationale
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-30T22:00:00.000000+00:00'
+tags:
+- compute
+- idempotent
+- reconvergence
+- pipeline
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-30T22:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  author: chris@croadfeldt
+  pipeline:
+    act: 3
+    sequence: 10
+    week: wk4
+    depends_on:
+    - uc-pipeline-composite-001
+  preconditions:
+  - Resource is realized and matches the previously declared intent
+  - Four-state stores are populated
+  postconditions:
+  - No new provider dispatch occurred
+  - Resource state is unchanged
+  - Audit trail records the no-op

--- a/dav/use-cases/compute/tenancy-data-model.yaml
+++ b/dav/use-cases/compute/tenancy-data-model.yaml
@@ -1,0 +1,52 @@
+uuid: uc-tenancy-data-model
+handle: compute/tenancy-data-model
+version: 1.0.0
+scenario:
+  description: 'Validation UC for A2: confirm UDLM models the data behind data-plane tenant isolation
+    — resource tenancy fields binding a resource to its tenant, and the tenant_boundary DCMGroup that
+    network/storage attachments are confined to.'
+  actor:
+    persona: application-team-member
+    profile: standard
+  intent: Validate UDLM models resource tenancy fields and the tenant_boundary DCMGroup
+  success_criteria:
+  - A resource record models the tenancy fields binding it to its tenant
+  - The tenant boundary is modeled as a tenant_boundary DCMGroup
+  - Network and storage attachments reference the tenant boundary in the model
+  - An attachment crossing the tenant boundary is representable as a rejected/violating state
+  - The isolation decision is representable in the audit model
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: hard_dependencies
+    policy_complexity: system_defaults_only
+    provider_landscape: mixed
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: resource tenancy fields + tenant_boundary DCMGroup modeled
+  - domain: policy
+    interaction: tenant-isolation applicability representable
+  - domain: audit
+    interaction: isolation decision representable
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: trifecta-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- a2
+- tenancy
+- data-model-validation
+- trifecta
+- udlm
+- standard-profile
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt
+  note: trifecta validation UC (Piotr-feedback DRs)

--- a/dav/use-cases/compute/vm-tenant-isolation-enforcement.yaml
+++ b/dav/use-cases/compute/vm-tenant-isolation-enforcement.yaml
@@ -1,0 +1,61 @@
+uuid: uc-tenant-iso-001
+handle: compute/vm-tenant-isolation-enforcement
+scenario:
+  description: A VM is provisioned for a team within a multi-tenant DCM deployment.
+    The platform must enforce tenant isolation at the data plane — the VM's network
+    and storage attachments are confined to the tenant boundary, and a tenant-isolation
+    policy is evaluated and applied before the attachments are realized. This is the
+    reusable data-plane tenancy building block, split out from compute/vm-standard-provision
+    (Piotr PR-65 #2) so the isolation concern is validated on its own.
+  actor:
+    persona: application-team-member
+    profile: standard
+  intent: Provision a VM whose network and storage attachments are confined to the
+    requesting team's tenant boundary
+  success_criteria:
+  - Tenant-isolation policy is evaluated and applied to the VM's network attachments
+  - Tenant-isolation policy is evaluated and applied to the VM's storage attachments
+  - Attachments that would cross the tenant boundary are rejected, not silently allowed
+  - The resource record carries the tenancy fields binding the VM to its tenant boundary
+  - The isolation decision (policies evaluated + outcome) is recorded in the audit trail
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: hard_dependencies
+    policy_complexity: multi_policy_chain
+    provider_landscape: mixed
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: policy
+    interaction: tenant-isolation policy evaluates network and storage attachments
+      against the tenant boundary
+  - domain: provider
+    interaction: network and storage providers realize attachments only within the
+      tenant boundary
+  - domain: data
+    interaction: resource record created with tenancy fields binding the VM to its
+      tenant_boundary DCMGroup
+  - domain: audit
+    interaction: isolation policies-evaluated and outcome recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- compute
+- vm
+- tenancy
+- data-plane-isolation
+- standard-profile
+- foundational
+- split-from-vm-standard-provision
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt

--- a/dav/use-cases/cross-domain/brownfield-adoption-capability.yaml
+++ b/dav/use-cases/cross-domain/brownfield-adoption-capability.yaml
@@ -1,0 +1,54 @@
+uuid: uc-brownfield-adoption-capability
+handle: cross-domain/brownfield-adoption-capability
+version: 1.0.0
+scenario:
+  description: 'Validation UC for DR-A: confirm DCM provides the capability to adopt an existing estate
+    in place (ingest hosts/groups/credentials as entities with zero resource recreation), track divergence
+    as drift during a coexistence window, perform the cutover authority flip (legacy->DCM-authoritative),
+    and remain reversible before cutover. This checks the CAPABILITY exists to support cross-domain/ansible-inventory-brownfield-ingestion.'
+  actor:
+    persona: platform-operator
+    profile: standard
+  intent: Validate DCM exposes the brownfield adopt-in-place + coexistence + cutover capability
+  success_criteria:
+  - DCM can ingest discovered resources as entities without recreating or restarting them (adopt-in-place)
+  - DCM tracks divergence between legacy-controlled state and ingested entities as drift during coexistence
+  - DCM supports a cutover that flips authority to the DCM API as the single control path
+  - Ingestion is reversible before cutover (removing DCM management leaves the estate as found)
+  - Post-cutover out-of-band change handling is a policy-configurable action (default reject+alert)
+  dimensions:
+    lifecycle_phase: brownfield_ingestion
+    resource_complexity: cross_dependency_payload
+    policy_complexity: multi_policy_chain
+    provider_landscape: mixed
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: provider
+    interaction: information provider enumerates the existing estate for adopt-in-place
+  - domain: policy
+    interaction: coexistence policy classifies drift by phase; cutover flips management authority
+  - domain: data
+    interaction: entities adopted with brownfield provenance; no resource recreation
+  - domain: audit
+    interaction: adoption, drift, and cutover recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: trifecta-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- dr-a
+- brownfield
+- capability-validation
+- trifecta
+- standard-profile
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt
+  note: trifecta validation UC (Piotr-feedback DRs)

--- a/dav/use-cases/cross-domain/brownfield-adoption-data-model.yaml
+++ b/dav/use-cases/cross-domain/brownfield-adoption-data-model.yaml
@@ -1,0 +1,54 @@
+uuid: uc-brownfield-adoption-data-model
+handle: cross-domain/brownfield-adoption-data-model
+version: 1.0.0
+scenario:
+  description: 'Validation UC for DR-A: confirm UDLM models the data needed for brownfield adoption —
+    brownfield provenance on entities, a per-entity management_authority (legacy|dcm) that flips at cutover,
+    Discovered-state drift records, DCMGroup mappings for ingested groups, and vault-backed credential
+    resources replacing embedded plaintext.'
+  actor:
+    persona: platform-operator
+    profile: standard
+  intent: Validate UDLM models the brownfield adoption data (provenance, management authority, drift)
+  success_criteria:
+  - Each ingested entity carries provenance marking it brownfield
+  - Each entity carries a management_authority field with values legacy or dcm
+  - Discovered-state drift records are modeled and persist across the coexistence window
+  - Ingested inventory groups map to DCMGroup entities with membership preserved
+  - Embedded plaintext credentials become vault-backed credential resources in the model
+  dimensions:
+    lifecycle_phase: brownfield_ingestion
+    resource_complexity: cross_dependency_payload
+    policy_complexity: system_defaults_only
+    provider_landscape: mixed
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: entities, DCMGroups, credential resources, and drift records modeled with brownfield
+      provenance
+  - domain: provider
+    interaction: config-management system represented as an information provider
+  - domain: audit
+    interaction: provenance and authority transitions recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: trifecta-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- dr-a
+- brownfield
+- data-model-validation
+- trifecta
+- udlm
+- standard-profile
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt
+  note: trifecta validation UC (Piotr-feedback DRs)

--- a/dav/use-cases/cross-domain/composite-service-provision.yaml
+++ b/dav/use-cases/cross-domain/composite-service-provision.yaml
@@ -1,0 +1,71 @@
+uuid: uc-pipeline-composite-001
+handle: cross-domain/composite-service-provision
+scenario:
+  description: An application team submits a composite service request (e.g., a
+    three-tier web application — web, app, database). DCM decomposes the composite
+    into constituents, resolves dependencies, evaluates validation policies
+    (including sovereignty constraints), selects providers via the placement engine,
+    and realizes each constituent in dependency order. This is the "easy consumption"
+    proof — a single intent produces a full running stack.
+  actor:
+    persona: application-team-member
+    profile: standard
+  intent: Provision a composite service from a single intent declaration
+  success_criteria:
+  - Composite service request is accepted and decomposed into constituents
+  - Dependencies are resolved and constituents are dispatched in the correct order
+    (dependency rounds)
+  - Validation policies (including sovereignty) are evaluated before each dispatch
+  - Each constituent is realized by the selected service provider
+  - All four states (intent, requested, realized, discovered) are populated for the
+    composite entity
+  - The composite entity status reflects OPERATIONAL when all required constituents
+    succeed
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: composite_service
+    policy_complexity: multi_validation
+    provider_landscape: multi_eligible
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: policy
+    interaction: validation policies evaluate sovereignty and business rules before
+      dispatch
+  - domain: provider
+    interaction: service providers realize each constituent
+  - domain: data
+    interaction: composite entity created across all four states
+  - domain: audit
+    interaction: full provisioning arc recorded with dependency ordering
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-30T22:00:00.000000+00:00'
+tags:
+- cross-domain
+- composite-service
+- provision
+- full-stack
+- pipeline
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-30T22:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  author: chris@croadfeldt
+  pipeline:
+    act: 2
+    sequence: 6
+    week: wk3
+    depends_on:
+    - uc-pipeline-catalog-001
+  preconditions:
+  - Composite service catalog item is registered and visible
+  - Actor holds a valid Keycloak token with tenant and role claims
+  postconditions:
+  - Composite service is realized with all constituents operational
+  - All four states reflect the complete provisioning arc
+  - Intent matches realized state

--- a/dav/use-cases/cross-domain/composite-service-to-catalog-item.yaml
+++ b/dav/use-cases/cross-domain/composite-service-to-catalog-item.yaml
@@ -1,0 +1,66 @@
+uuid: uc-pipeline-catalog-001
+handle: cross-domain/composite-service-to-catalog-item
+scenario:
+  description: A platform engineer registers a composite service definition as a
+    catalog item in DCM. The composite service declares multiple constituent resource
+    types (e.g., web tier, app tier, database tier) with dependencies between them.
+    A process provider may convert an external format (e.g., likeC4) to DCM's native
+    composite service format before registration. DCM does not natively speak
+    customer-specific formats; UDLM is the core design language.
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Register a composite service definition as a catalog item
+  success_criteria:
+  - Composite service definition is registered as a catalog item
+  - All constituent resource types are declared with dependencies
+  - Dependency graph is acyclic and validated
+  - Catalog item is visible in the service catalog
+  - Registration is recorded in the audit trail
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: composite_service
+    policy_complexity: single_validation
+    provider_landscape: single_eligible
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: provider
+    interaction: process provider converts external format if needed; service provider
+      registers catalog item
+  - domain: data
+    interaction: catalog item and constituent definitions created
+  - domain: policy
+    interaction: validation policy checks composite definition completeness
+  - domain: audit
+    interaction: registration recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-30T22:00:00.000000+00:00'
+tags:
+- cross-domain
+- composite-service
+- catalog
+- pipeline
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-30T22:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  author: chris@croadfeldt
+  pipeline:
+    act: 2
+    sequence: 5
+    week: wk3
+    depends_on:
+    - uc-pipeline-cp-001
+    - uc-pipeline-authn-001
+  preconditions:
+  - DCM control plane is deployed and accepting requests
+  - Actor holds a valid Keycloak token
+  postconditions:
+  - Composite service catalog item is registered and visible
+  - Constituent dependency graph is validated and stored

--- a/dav/use-cases/cross-domain/cross-dcm-audit-data-model.yaml
+++ b/dav/use-cases/cross-domain/cross-dcm-audit-data-model.yaml
@@ -1,0 +1,50 @@
+uuid: uc-cross-dcm-audit-data-model
+handle: cross-domain/cross-dcm-audit-data-model
+version: 1.0.0
+scenario:
+  description: 'Validation UC for A4: confirm UDLM models the data for peer-coordinated decommission —
+    peer-ack metadata on the released resource and a cross-DCM audit record stitched consistently across
+    both instances.'
+  actor:
+    persona: sovereign-tenant-admin
+    profile: sovereign
+  intent: Validate UDLM models peer-ack metadata and a consistent cross-DCM audit record
+  success_criteria:
+  - The released resource record models peer-acknowledgement metadata
+  - A cross-DCM audit record is modeled and is consistent across both instances
+  - Pending (held) state is representable when the peer is unreachable
+  - The peer's attested capability set at transaction time is recorded
+  - Residency-check evidence is captured in the model
+  dimensions:
+    lifecycle_phase: decommission
+    resource_complexity: hard_dependencies
+    policy_complexity: system_defaults_only
+    provider_landscape: peer_dcm_required
+    governance_context: sovereignty_enforced
+    failure_mode: happy_path
+  profile: sovereign
+  expected_domain_interactions:
+  - domain: data
+    interaction: peer-ack metadata + cross-DCM audit record modeled consistently
+  - domain: audit
+    interaction: cross-instance audit stitched
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: trifecta-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- a4
+- peer-dcm
+- data-model-validation
+- trifecta
+- udlm
+- sovereign-profile
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt
+  note: trifecta validation UC (Piotr-feedback DRs)

--- a/dav/use-cases/cross-domain/dynamic-rehydration.yaml
+++ b/dav/use-cases/cross-domain/dynamic-rehydration.yaml
@@ -1,0 +1,71 @@
+uuid: uc-pipeline-rehydrate-001
+handle: cross-domain/dynamic-rehydration
+scenario:
+  description: All managed resources are destroyed (simulating a disaster). The system
+    reads the stored intent states and dependency graph from the data model, derives
+    a rebuild plan dynamically (not a static replay), re-evaluates validation policies
+    (including sovereignty), resolves providers via the placement engine, and executes
+    the rebuild. This is the headline demo — proving that DCM can reconstruct a full
+    environment from its data model alone.
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Dynamically rebuild all resources from stored intent after total destruction
+  success_criteria:
+  - All resources are destroyed (realized state cleared)
+  - System derives a rebuild plan from stored intent and dependency graph
+  - The plan is computed dynamically, not replayed from a recorded sequence
+  - Validation policies (including sovereignty) are re-evaluated during rebuild
+  - Providers are resolved via the standard placement engine
+  - All resources are re-realized in the correct dependency order
+  - UUIDs are preserved across the destroy/rebuild cycle
+  - Post-rebuild realized state matches the original intent state
+  dimensions:
+    lifecycle_phase: rehydration_faithful
+    resource_complexity: full_stack
+    policy_complexity: multi_validation
+    provider_landscape: multi_eligible
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: intent state read, dependency graph computed, all four states repopulated
+  - domain: policy
+    interaction: validation policies re-evaluated including sovereignty
+  - domain: provider
+    interaction: service providers re-realize each resource
+  - domain: audit
+    interaction: full destroy and rebuild arc recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-30T22:00:00.000000+00:00'
+tags:
+- cross-domain
+- rehydration
+- dynamic
+- rebuild
+- headline
+- pipeline
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-30T22:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  author: chris@croadfeldt
+  pipeline:
+    act: 4
+    sequence: 11
+    week: wk4
+    depends_on:
+    - uc-pipeline-composite-001
+    - uc-pipeline-4state-001
+  preconditions:
+  - Resources were previously realized and are now destroyed
+  - Intent state and dependency graph are preserved in the data stores
+  postconditions:
+  - All resources are re-realized matching original intent
+  - UUIDs are preserved
+  - Four-state stores are fully repopulated

--- a/dav/use-cases/cross-domain/peer-coordination-capability.yaml
+++ b/dav/use-cases/cross-domain/peer-coordination-capability.yaml
@@ -1,0 +1,51 @@
+uuid: uc-peer-coordination-capability
+handle: cross-domain/peer-coordination-capability
+version: 1.0.0
+scenario:
+  description: 'Validation UC for A4: confirm DCM provides the peer-coordination capability — a two-phase
+    release across DCM instances, verifying the peer meets the provenance floor before coordinating, releasing
+    local only after peer-ack, and holding (not silently completing) when the peer is unreachable.'
+  actor:
+    persona: sovereign-tenant-admin
+    profile: sovereign
+  intent: Validate DCM can run a peer-coordinated two-phase release with hold-on-unreachable
+  success_criteria:
+  - DCM coordinates a two-phase release with a peer DCM instance
+  - The peer's attested capability set is verified to meet the provenance floor before coordinating
+  - Local release happens only after the peer acknowledges
+  - If the peer is unreachable the operation is held pending, not silently completed
+  - Residency constraints are checked during the coordinated wind-down
+  dimensions:
+    lifecycle_phase: decommission
+    resource_complexity: hard_dependencies
+    policy_complexity: cross_domain_constraint
+    provider_landscape: peer_dcm_required
+    governance_context: sovereignty_enforced
+    failure_mode: peer_dcm_disconnect
+  profile: sovereign
+  expected_domain_interactions:
+  - domain: provider
+    interaction: peer_dcm provider coordinates the two-phase release
+  - domain: policy
+    interaction: sovereignty policy mandates the peer replica and verifies the provenance floor
+  - domain: audit
+    interaction: peer-ack evidence captured
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: trifecta-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- a4
+- peer-dcm
+- capability-validation
+- trifecta
+- sovereign-profile
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt
+  note: trifecta validation UC (Piotr-feedback DRs)

--- a/dav/use-cases/cross-domain/profile-approved-list-data-model.yaml
+++ b/dav/use-cases/cross-domain/profile-approved-list-data-model.yaml
@@ -1,0 +1,55 @@
+uuid: uc-profile-approved-list-data-model
+handle: cross-domain/profile-approved-list-data-model
+version: 1.0.0
+scenario:
+  description: 'Validation UC for DR-B: confirm UDLM models the approved-list profile data — the instance
+    approved_profiles set + default_profile, a profile as a named capability set, the tenant_boundary
+    and policy_profile DCMGroups, and the compliance/sovereignty overlay (Sovereignty Zone + Accreditation)
+    as a separate axis composed with the profile.'
+  actor:
+    persona: platform-engineer
+    profile: fsi
+  intent: Validate UDLM models approved-list profiles, default, and the profile/overlay binding
+  success_criteria:
+  - The instance models an approved_profiles set and a default_profile
+  - A profile is modeled as a named, versioned capability set (not a fixed enum value)
+  - Tenant is a tenant_boundary DCMGroup bound to a policy_profile DCMGroup — no separate mapping artifact
+  - Compliance/sovereignty overlay (Sovereignty Zone + Accreditation) is a distinct, composable axis
+  - Quota allocations and claims-mapping references are modeled on the tenant
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: composite_service
+    policy_complexity: system_defaults_only
+    provider_landscape: mixed
+    governance_context: compliance_gated
+    failure_mode: happy_path
+  profile: fsi
+  expected_domain_interactions:
+  - domain: data
+    interaction: approved_profiles, default_profile, capability-set profiles, DCMGroups, overlay, quotas
+      modeled
+  - domain: policy
+    interaction: profile binding expressed via policy_profile DCMGroup
+  - domain: audit
+    interaction: profile + overlay binding recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: trifecta-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- dr-b
+- profile
+- approved-list
+- data-model-validation
+- trifecta
+- udlm
+- fsi-profile
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt
+  note: trifecta validation UC (Piotr-feedback DRs)

--- a/dav/use-cases/cross-domain/profile-resolution-capability.yaml
+++ b/dav/use-cases/cross-domain/profile-resolution-capability.yaml
@@ -1,0 +1,55 @@
+uuid: uc-profile-resolution-capability
+handle: cross-domain/profile-resolution-capability
+version: 1.0.0
+scenario:
+  description: 'Validation UC for DR-B: confirm DCM provides profile resolution (an instance declares
+    an approved list of profiles + a default; near-term the default applies instance-wide) and atomic
+    tenant onboarding (identity boundary + profile binding + quotas + auth claims, all-or-nothing).'
+  actor:
+    persona: platform-engineer
+    profile: fsi
+  intent: Validate DCM resolves the instance profile from the approved list + default and onboards atomically
+  success_criteria:
+  - DCM resolves the instance profile from the platform approved list and default
+  - Tenant onboarding binds the tenant to the resolved profile via a policy_profile DCMGroup
+  - Onboarding is atomic — either all steps persist or none do
+  - A compliance/sovereignty overlay is composed with the profile, not folded into it
+  - Profiles are capability sets compared by content set-containment, not by rank
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: composite_service
+    policy_complexity: orchestration_flow_static
+    provider_landscape: mixed
+    governance_context: compliance_gated
+    failure_mode: happy_path
+  profile: fsi
+  expected_domain_interactions:
+  - domain: policy
+    interaction: profile resolution from approved-list+default; onboarding atomicity enforced by orchestration
+      flow policy
+  - domain: data
+    interaction: tenant bound to instance profile; compliance overlay composed separately
+  - domain: provider
+    interaction: auth provider configured with the tenant claims-mapping reference
+  - domain: audit
+    interaction: atomic onboarding recorded as one record
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: trifecta-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- dr-b
+- profile
+- approved-list
+- capability-validation
+- trifecta
+- fsi-profile
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt
+  note: trifecta validation UC (Piotr-feedback DRs)

--- a/dav/use-cases/cross-domain/provider-portable-rebuild.yaml
+++ b/dav/use-cases/cross-domain/provider-portable-rebuild.yaml
@@ -1,0 +1,69 @@
+uuid: uc-pipeline-portable-001
+handle: cross-domain/provider-portable-rebuild
+scenario:
+  description: A service provider becomes unavailable during or after provisioning.
+    The placement engine re-resolves the affected resources onto an alternate eligible
+    provider. Provider-specific references are rewritten. The rebuild proceeds using
+    only the intent state and the new provider's capabilities. This UC validates that
+    DCM's provider abstraction enables true portability — resources are not locked
+    to a single provider.
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Re-resolve and rebuild resources on an alternate provider after provider
+    failure
+  success_criteria:
+  - Provider unavailability is detected (via health check or explicit deregistration)
+  - Affected resources are re-resolved onto an alternate eligible provider
+  - Provider-specific references (naturalization) are rewritten for the new provider
+  - Resources are re-realized on the alternate provider
+  - Realized state matches the original intent (provider-neutral fields)
+  - The re-resolution and rebuild are recorded in the audit trail
+  dimensions:
+    lifecycle_phase: rehydration_provider_portable
+    resource_complexity: multi_dependent
+    policy_complexity: multi_validation
+    provider_landscape: multi_eligible
+    governance_context: standard_governance
+    failure_mode: single_provider_failure
+  profile: standard
+  expected_domain_interactions:
+  - domain: provider
+    interaction: original provider unavailable; alternate selected via placement engine
+  - domain: policy
+    interaction: validation policies re-evaluated for alternate provider
+  - domain: data
+    interaction: provider references rewritten; realized state updated
+  - domain: audit
+    interaction: portability event and re-resolution recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-30T22:00:00.000000+00:00'
+tags:
+- cross-domain
+- portability
+- provider
+- rebuild
+- stretch
+- pipeline
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-30T22:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  author: chris@croadfeldt
+  pipeline:
+    act: 5
+    sequence: 13
+    week: wk5
+    depends_on:
+    - uc-pipeline-composite-001
+  preconditions:
+  - Resources are realized on a specific provider
+  - An alternate eligible provider is registered
+  - The original provider becomes unavailable
+  postconditions:
+  - Resources are re-realized on the alternate provider
+  - Intent-to-realized alignment is maintained

--- a/dav/use-cases/data/four-state-store-conformance.yaml
+++ b/dav/use-cases/data/four-state-store-conformance.yaml
@@ -1,0 +1,61 @@
+uuid: uc-pipeline-4state-001
+handle: data/four-state-store-conformance
+scenario:
+  description: A platform engineer verifies that the four-state data stores (intent,
+    requested, realized, discovered) conform to the UDLM specification. Each store
+    maintains the correct entity lifecycle, UUIDs are stable across states, and state
+    transitions follow the declared rules. This UC validates the data substrate that
+    all provisioning, drift detection, and rehydration UCs depend on.
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Verify four-state data store conformance to the UDLM specification
+  success_criteria:
+  - Intent store preserves the original consumer declaration immutably
+  - Requested store records the policy-approved dispatch payload
+  - Realized store records provider-confirmed outcomes as authoritative
+  - Discovered store records independently observed current state
+  - Entity UUIDs are stable across all four states
+  - State transitions follow UDLM lifecycle rules (no skipping states)
+  - Four-state stores are queryable via the standard API
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: single_no_deps
+    policy_complexity: no_policy
+    provider_landscape: single_eligible
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: all four state stores are exercised and verified
+  - domain: audit
+    interaction: conformance verification recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-30T22:00:00.000000+00:00'
+tags:
+- data
+- four-state
+- udlm
+- conformance
+- pipeline
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-30T22:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  author: chris@croadfeldt
+  pipeline:
+    act: 2
+    sequence: 7
+    week: wk2-3
+    depends_on:
+    - uc-pipeline-cp-001
+  preconditions:
+  - DCM control plane is deployed with four-state stores initialized
+  postconditions:
+  - Four-state stores are UDLM-conformant and queryable
+  - Entity lifecycle transitions are validated

--- a/dav/use-cases/governance/audit-chain-data-model.yaml
+++ b/dav/use-cases/governance/audit-chain-data-model.yaml
@@ -1,0 +1,50 @@
+uuid: uc-audit-chain-data-model
+handle: governance/audit-chain-data-model
+version: 1.0.0
+scenario:
+  description: 'Validation UC for DR-D: confirm UDLM models the audit-chain data — audit events, epochs,
+    signed tree heads, and inclusion/consistency proofs as append-only, schema-defined artifacts addressable
+    by handle and epoch.'
+  actor:
+    persona: compliance-auditor
+    profile: sovereign
+  intent: Validate UDLM models the audit chain (events, epochs, tree heads, proofs) as append-only
+  success_criteria:
+  - Audit events are modeled as append-only artifacts addressable by handle and epoch
+  - Epochs and their signed tree heads are modeled
+  - Inclusion and consistency proofs are modeled as read-only derived artifacts
+  - The model enforces append-only semantics (no in-place mutation of recorded events)
+  - Signing/attestation metadata for tree heads is modeled
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: single_no_deps
+    policy_complexity: system_defaults_only
+    provider_landscape: single_eligible
+    governance_context: audit_heavy
+    failure_mode: happy_path
+  profile: sovereign
+  expected_domain_interactions:
+  - domain: data
+    interaction: audit events, epochs, tree heads, and proofs modeled append-only
+  - domain: audit
+    interaction: proof artifacts derived read-only from the chain
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: trifecta-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- dr-d
+- audit
+- data-model-validation
+- trifecta
+- udlm
+- sovereign-profile
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt
+  note: trifecta validation UC (Piotr-feedback DRs)

--- a/dav/use-cases/governance/audit-chain-output-verification.yaml
+++ b/dav/use-cases/governance/audit-chain-output-verification.yaml
@@ -1,0 +1,54 @@
+uuid: uc-audit-chain-output-verification
+handle: governance/audit-chain-output-verification
+version: 1.0.0
+scenario:
+  description: 'Validation UC for DR-D (closes the produce->verify loop): an auditor takes the signed
+    tree heads + inclusion and consistency proofs DCM produced and independently re-verifies them; the
+    proofs validate for untampered events, and a tampered or missing event is detected. This validates
+    the OUTPUT of governance/audit-merkle-tree-verification, not just that proofs are produced.'
+  actor:
+    persona: compliance-auditor
+    profile: sovereign
+  intent: Validate an auditor can independently re-verify the audit-chain proofs and detect tampering
+  success_criteria:
+  - Independently re-verifying inclusion proofs against the signed tree heads succeeds for untampered
+    events
+  - Consistency proofs confirm the tree heads form a coherent append-only sequence
+  - A tampered or removed event is detected (its proof fails verification)
+  - Verification is a read-only operation that modifies no tenant resources
+  - Under sovereign profile the signing key material never leaves the boundary during verification
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: single_no_deps
+    policy_complexity: cross_domain_constraint
+    provider_landscape: single_eligible
+    governance_context: audit_heavy
+    failure_mode: happy_path
+  profile: sovereign
+  expected_domain_interactions:
+  - domain: audit
+    interaction: auditor re-verifies inclusion and consistency proofs against signed tree heads
+  - domain: policy
+    interaction: sovereignty policy confirms signing-key residency during verification
+  - domain: data
+    interaction: audit events looked up by handle and epoch for proof generation
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: trifecta-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- dr-d
+- audit
+- output-verification
+- produce-verify-loop
+- trifecta
+- sovereign-profile
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt
+  note: trifecta validation UC (Piotr-feedback DRs)

--- a/dav/use-cases/governance/audit-chain-proofs-capability.yaml
+++ b/dav/use-cases/governance/audit-chain-proofs-capability.yaml
@@ -1,0 +1,53 @@
+uuid: uc-audit-chain-proofs-capability
+handle: governance/audit-chain-proofs-capability
+version: 1.0.0
+scenario:
+  description: 'Validation UC for DR-D: confirm DCM provides the transparency-log capability — produce
+    signed Merkle tree heads, inclusion proofs for requested events, and consistency proofs across epochs,
+    with signing key material kept in-boundary under sovereign profile. (Single-signer v1; external witness
+    validation is a tracked follow-up.)'
+  actor:
+    persona: compliance-auditor
+    profile: sovereign
+  intent: Validate DCM can produce signed tree heads + inclusion/consistency proofs with in-boundary signing
+  success_criteria:
+  - DCM produces signed tree heads for every audit epoch covering a requested range
+  - DCM produces inclusion proofs for each requested event
+  - DCM produces consistency proofs across epoch tree heads
+  - Signing key material is kept within the sovereignty boundary
+  - v1 is single-signer; split-view/equivocation is a known limitation pending external witnesses
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: single_no_deps
+    policy_complexity: cross_domain_constraint
+    provider_landscape: single_eligible
+    governance_context: audit_heavy
+    failure_mode: happy_path
+  profile: sovereign
+  expected_domain_interactions:
+  - domain: audit
+    interaction: DCM generates tree heads, inclusion proofs, and consistency proofs
+  - domain: policy
+    interaction: sovereignty policy pins signing-key residency
+  - domain: provider
+    interaction: information provider serves tree-heads and proofs
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: trifecta-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- dr-d
+- audit
+- transparency-log
+- capability-validation
+- trifecta
+- sovereign-profile
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt
+  note: trifecta validation UC (Piotr-feedback DRs)

--- a/dav/use-cases/governance/policy-applicability-data-model.yaml
+++ b/dav/use-cases/governance/policy-applicability-data-model.yaml
@@ -1,0 +1,52 @@
+uuid: uc-policy-applicability-data-model
+handle: governance/policy-applicability-data-model
+version: 1.0.0
+scenario:
+  description: 'Validation UC for DR-E: confirm UDLM models the data behind policy applicability — the
+    approved-list/default, the resolved profile and its policy set on the request record, and a three-state
+    policy outcome (evaluated-pass / evaluated-fail / out-of-scope) in the audit model.'
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Validate UDLM models resolved-profile policy sets and three-state audit outcomes
+  success_criteria:
+  - The request record models the resolved profile and the set of policies it carries
+  - 'The audit model represents three policy outcomes: evaluated-pass, evaluated-fail, out-of-scope'
+  - Out-of-scope is a first-class modeled outcome, not an absence or a pass
+  - Approved-list and default profile are modeled at the instance level
+  - Policy membership in a profile is modeled (which policies a profile carries)
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: cross_dependency_payload
+    policy_complexity: system_defaults_only
+    provider_landscape: mixed
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: resolved profile + policy set on the request; three-state outcome modeled
+  - domain: policy
+    interaction: profile->policy membership modeled
+  - domain: audit
+    interaction: three-state outcome represented
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: trifecta-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- dr-e
+- policy
+- data-model-validation
+- trifecta
+- udlm
+- standard-profile
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt
+  note: trifecta validation UC (Piotr-feedback DRs)

--- a/dav/use-cases/governance/policy-resolution-capability.yaml
+++ b/dav/use-cases/governance/policy-resolution-capability.yaml
@@ -1,0 +1,53 @@
+uuid: uc-policy-resolution-capability
+handle: governance/policy-resolution-capability
+version: 1.0.0
+scenario:
+  description: 'Validation UC for DR-E: confirm DCM provides policy applicability by resolved-profile
+    membership — it resolves the request profile (approved-list selection or platform default), evaluates
+    only the policies in that profile, and records a three-state audit outcome (evaluated-pass / evaluated-fail
+    / out-of-scope) with out-of-scope distinct from skipped-and-passed.'
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Validate DCM resolves the request profile and produces three-state policy outcomes
+  success_criteria:
+  - DCM resolves the request's profile and selects that profile's policies by construction
+  - Policies not in the resolved profile are not evaluated
+  - The audit outcome distinguishes evaluated-pass, evaluated-fail, and out-of-scope
+  - Out-of-scope policies are never recorded as skipped-and-passed (no silent soft-pass)
+  - No global policy fall-through evaluates policies outside the resolved profile
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: cross_dependency_payload
+    policy_complexity: governance_matrix_enforcement
+    provider_landscape: mixed
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: policy
+    interaction: engine resolves profile, selects its policies, emits three-state outcomes
+  - domain: data
+    interaction: request stores the resolved profile and its policy set
+  - domain: audit
+    interaction: policies-evaluated listed honestly with three-state outcomes
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: trifecta-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- dr-e
+- policy
+- resolved-profile
+- capability-validation
+- trifecta
+- standard-profile
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt
+  note: trifecta validation UC (Piotr-feedback DRs)

--- a/dav/use-cases/governance/sovereignty-validation-policy.yaml
+++ b/dav/use-cases/governance/sovereignty-validation-policy.yaml
@@ -1,0 +1,66 @@
+uuid: uc-pipeline-sov-001
+handle: governance/sovereignty-validation-policy
+scenario:
+  description: A platform engineer configures a sovereignty validation policy that
+    blocks resource placement in non-compliant zones. When a provisioning request
+    arrives, the validation policy (enforcement_class compliance) evaluates the request
+    against the declared sovereignty zone constraints. Non-compliant placements are
+    denied. This UC validates that sovereignty constraints are enforced as hard gates
+    in the provisioning pipeline.
+  actor:
+    persona: platform-engineer
+    profile: sovereign
+  intent: Configure and enforce sovereignty validation policy for resource placement
+  success_criteria:
+  - Sovereignty validation policy is registered and active
+  - Placement requests within compliant zones are approved
+  - Placement requests to non-compliant zones are denied with a clear sovereignty
+    violation error
+  - Policy evaluation and outcome are recorded in the audit trail
+  - The policy operates correctly in shadow mode before enforcement
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: single_no_deps
+    policy_complexity: cross_domain
+    provider_landscape: multi_eligible
+    governance_context: sovereign_mandate
+    failure_mode: happy_path
+  profile: sovereign
+  expected_domain_interactions:
+  - domain: policy
+    interaction: sovereignty validation policy evaluates placement constraints
+  - domain: provider
+    interaction: placement engine selects only compliant providers
+  - domain: data
+    interaction: policy evaluation results stored
+  - domain: audit
+    interaction: sovereignty evaluation recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-30T22:00:00.000000+00:00'
+tags:
+- governance
+- sovereignty
+- validation-policy
+- pipeline
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-30T22:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  author: chris@croadfeldt
+  pipeline:
+    act: 2
+    sequence: 8
+    week: wk3
+    depends_on:
+    - uc-pipeline-cp-001
+  preconditions:
+  - DCM control plane is deployed
+  - Sovereignty zones are registered
+  - At least one validation policy with enforcement_class compliance is configured
+  postconditions:
+  - Sovereignty constraints are enforced at placement time
+  - Non-compliant placements are blocked

--- a/dav/use-cases/identity/actor-authentication.yaml
+++ b/dav/use-cases/identity/actor-authentication.yaml
@@ -1,0 +1,59 @@
+uuid: uc-pipeline-authn-001
+handle: identity/actor-authentication
+scenario:
+  description: An actor authenticates against the identity provider (Keycloak). The
+    control plane validates the token and maps claims (tenant, roles, profile) to a
+    DCM actor identity. This is the foundational authentication step that all other
+    pipeline UCs depend on. Keycloak handles authentication; authorization is a
+    separate concern (authz model TBD — Authorino vs Kessel vs OPA-native).
+  actor:
+    persona: application-team-member
+    profile: standard
+  intent: Authenticate against the identity provider and obtain a DCM actor identity
+  success_criteria:
+  - Actor receives a valid token with tenant and role claims
+  - Control plane validates the token and resolves it to a DCM actor identity
+  - Authentication event is recorded in the audit trail
+  - Invalid or expired tokens are rejected with a clear error
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: single_no_deps
+    policy_complexity: no_policy
+    provider_landscape: single_eligible
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: identity
+    interaction: Keycloak validates credentials and issues token
+  - domain: data
+    interaction: actor identity reference created or resolved
+  - domain: audit
+    interaction: authentication event recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-30T22:00:00.000000+00:00'
+tags:
+- identity
+- authentication
+- keycloak
+- foundational
+- pipeline
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-30T22:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  author: chris@croadfeldt
+  pipeline:
+    act: 0
+    sequence: 1
+    week: wk2
+    depends_on: []
+  preconditions:
+  - Keycloak is deployed and configured with the DCM realm
+  postconditions:
+  - Actor holds a valid Keycloak token with tenant and role claims
+  - Control plane has resolved the actor's DCM identity

--- a/dav/use-cases/identity/connected-delegation.yaml
+++ b/dav/use-cases/identity/connected-delegation.yaml
@@ -1,0 +1,65 @@
+uuid: uc-identity-deleg-001
+handle: identity/connected-delegation
+scenario:
+  description: A request requires an authorization decision (is this actor a member
+    of the group permitted to perform the action?). In a connected deployment, DCM
+    DELEGATES the authn/authz resolution to the IdP (Keycloak/RHSSO) at decision time
+    and does NOT maintain an authoritative cache of user/group membership. DCM persists
+    only references (subject/group IDs, claims mappings); the IdP is authoritative.
+    This is the connected happy path and the capability that makes DR-C real — because
+    DCM resolves live and holds no membership cache, there is nothing to drift in the
+    connected case (the disconnected/sovereign projection-drift case is
+    identity/auth-provider-drift-detection). Validates that DCM treats identity as a
+    delegated provider capability, not a thing it re-owns.
+  actor:
+    persona: application-team-member
+    profile: prod
+  intent: Have an access decision resolved by delegating to the authoritative IdP,
+    with DCM holding only references and no membership cache
+  success_criteria:
+  - The authorization decision is resolved by querying the IdP at decision time
+  - DCM persists only identity references (subject/group IDs, claims mappings) — never
+    an authoritative membership store
+  - No DCM-side membership cache is consulted as a source of truth for the decision
+  - The decision and the IdP as its source are recorded in the audit trail
+  - With the IdP authoritative and live, there is no DCM identity cache that can drift
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: single_no_deps
+    policy_complexity: single_validation
+    provider_landscape: single_eligible
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: prod
+  expected_domain_interactions:
+  - domain: provider
+    interaction: auth provider delegates the authz resolution to the IdP at decision time
+  - domain: data
+    interaction: only identity references / claims mappings are read; no membership
+      cache is the system of record
+  - domain: policy
+    interaction: the access gate consumes the IdP-resolved decision
+  - domain: audit
+    interaction: decision recorded with the IdP as the authoritative source
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- identity
+- auth
+- delegated-identity
+- idp-authoritative
+- no-membership-cache
+- prod-profile
+- happy-path
+- foundational
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt

--- a/dav/use-cases/identity/identity-reference-data-model.yaml
+++ b/dav/use-cases/identity/identity-reference-data-model.yaml
@@ -1,0 +1,54 @@
+uuid: uc-identity-reference-data-model
+handle: identity/identity-reference-data-model
+version: 1.0.0
+scenario:
+  description: 'Validation UC for DR-C: confirm UDLM models delegated identity correctly — DCM holds identity
+    references (subject/group IDs, claims mappings) and, only under disconnected/sovereign, an immutable
+    point-in-time projection marked provenance=observed. DCM is never the authoritative system of record
+    for membership.'
+  actor:
+    persona: platform-engineer
+    profile: sovereign
+  intent: Validate UDLM models identity as references + observed projection, not a membership store
+  success_criteria:
+  - Identity references (subject/group IDs, claims mappings) are modeled
+  - An optional point-in-time identity projection is modeled with provenance=observed
+  - The model marks the IdP as authoritative; DCM is not the membership system of record
+  - The projection is gated to disconnected/sovereign use, not a default cache
+  - Divergence between projection and IdP is representable as a drift record
+  dimensions:
+    lifecycle_phase: drift_detection
+    resource_complexity: cross_dependency_payload
+    policy_complexity: human_escalation_required
+    provider_landscape: single_eligible
+    governance_context: sovereignty_enforced
+    failure_mode: data_inconsistency
+  profile: sovereign
+  expected_domain_interactions:
+  - domain: data
+    interaction: identity references + observed projection modeled; IdP authoritative
+  - domain: provider
+    interaction: auth provider is the delegation surface to the IdP
+  - domain: audit
+    interaction: projection provenance and divergence recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: trifecta-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- dr-c
+- identity
+- delegated-identity
+- data-model-validation
+- trifecta
+- udlm
+- sovereign-profile
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt
+  note: trifecta validation UC (Piotr-feedback DRs)

--- a/dav/use-cases/infrastructure/bare-metal-pxe-bootstrap.yaml
+++ b/dav/use-cases/infrastructure/bare-metal-pxe-bootstrap.yaml
@@ -1,0 +1,61 @@
+uuid: uc-pipeline-bm-001
+handle: infrastructure/bare-metal-pxe-bootstrap
+scenario:
+  description: A platform engineer boots bare-metal nodes via PXE. The discovery ISO
+    phones home with hardware inventory. ABI (Agent-Based Installer) installs the
+    operating system and base packages. This UC validates the bootstrap path from
+    powered-off hardware to a node ready for cluster formation. Deployment target is
+    containers (Podman/OCP); no direct OS/KVM install.
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Bootstrap bare-metal nodes via PXE and ABI to a cluster-ready state
+  success_criteria:
+  - Bare-metal nodes PXE-boot from the discovery ISO
+  - Each node phones home with hardware inventory (CPU, memory, disk, NIC)
+  - ABI completes OS installation and base package deployment
+  - Node is accessible via SSH/console and reports healthy status
+  - Bootstrap events are recorded in the audit trail
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: single_with_deps
+    policy_complexity: single_validation
+    provider_landscape: single_eligible
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: provider
+    interaction: bare-metal service provider executes PXE boot and ABI install
+  - domain: data
+    interaction: hardware inventory records created in discovered state
+  - domain: audit
+    interaction: bootstrap events recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-30T22:00:00.000000+00:00'
+tags:
+- infrastructure
+- bare-metal
+- pxe
+- bootstrap
+- pipeline
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-30T22:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  author: chris@croadfeldt
+  pipeline:
+    act: 1
+    sequence: 2
+    week: wk2
+    depends_on:
+    - uc-pipeline-authn-001
+  preconditions:
+  - Actor holds a valid Keycloak token with platform-engineer role claims
+  postconditions:
+  - Bare-metal nodes are bootstrapped with OS and base packages
+  - Hardware inventory is recorded in the discovered store

--- a/dav/use-cases/infrastructure/cluster-bootstrap.yaml
+++ b/dav/use-cases/infrastructure/cluster-bootstrap.yaml
@@ -1,0 +1,61 @@
+uuid: uc-pipeline-cluster-001
+handle: infrastructure/cluster-bootstrap
+scenario:
+  description: A platform engineer forms a Kubernetes cluster from bootstrapped
+    bare-metal nodes. The cluster is stood up using containers (Podman/OCP) on the
+    bootstrapped nodes. This UC validates that the infrastructure substrate is ready
+    for the control plane deployment.
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Form a Kubernetes cluster from bootstrapped bare-metal nodes
+  success_criteria:
+  - Kubernetes cluster is formed from bootstrapped nodes
+  - Cluster API server is reachable and responding
+  - Node membership matches the declared intent
+  - Cluster formation is recorded in the audit trail
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: multi_dependent
+    policy_complexity: single_validation
+    provider_landscape: single_eligible
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: provider
+    interaction: cluster service provider orchestrates node joining
+  - domain: data
+    interaction: cluster entity created in intent and realized stores
+  - domain: policy
+    interaction: validation policy checks node readiness before joining
+  - domain: audit
+    interaction: cluster formation recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-30T22:00:00.000000+00:00'
+tags:
+- infrastructure
+- cluster
+- kubernetes
+- bootstrap
+- pipeline
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-30T22:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  author: chris@croadfeldt
+  pipeline:
+    act: 1
+    sequence: 3
+    week: wk2
+    depends_on:
+    - uc-pipeline-bm-001
+  preconditions:
+  - Bare-metal nodes are bootstrapped with OS and base packages
+  postconditions:
+  - Kubernetes cluster is operational with all declared nodes joined
+  - Cluster entity is recorded in intent and realized stores

--- a/dav/use-cases/infrastructure/control-plane-deployment.yaml
+++ b/dav/use-cases/infrastructure/control-plane-deployment.yaml
@@ -1,0 +1,59 @@
+uuid: uc-pipeline-cp-001
+handle: infrastructure/control-plane-deployment
+scenario:
+  description: A platform engineer deploys the DCM control plane onto the bootstrapped
+    Kubernetes cluster. The control plane includes the convergence engine, policy
+    engine, request orchestrator, and the four-state data stores. This UC validates
+    that DCM itself is operational and ready to accept requests.
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Deploy the DCM control plane onto the Kubernetes cluster
+  success_criteria:
+  - DCM control plane components are deployed and healthy (livez/readyz passing)
+  - Four-state data stores (intent, requested, realized, discovered) are initialized
+  - Policy engine is operational and evaluating
+  - Request orchestrator is accepting events
+  - Control plane deployment is recorded in the audit trail
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: multi_dependent
+    policy_complexity: no_policy
+    provider_landscape: single_eligible
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: provider
+    interaction: container runtime deploys control plane pods
+  - domain: data
+    interaction: control plane entities created
+  - domain: audit
+    interaction: deployment events recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-30T22:00:00.000000+00:00'
+tags:
+- infrastructure
+- control-plane
+- deployment
+- pipeline
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-30T22:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  author: chris@croadfeldt
+  pipeline:
+    act: 1
+    sequence: 4
+    week: wk2
+    depends_on:
+    - uc-pipeline-cluster-001
+  preconditions:
+  - Kubernetes cluster is operational with all declared nodes joined
+  postconditions:
+  - DCM control plane is deployed and accepting requests
+  - Four-state stores are initialized and UDLM-conformant

--- a/dav/use-cases/infrastructure/profile-based-deployment.yaml
+++ b/dav/use-cases/infrastructure/profile-based-deployment.yaml
@@ -1,0 +1,66 @@
+uuid: uc-pipeline-profile-001
+handle: infrastructure/profile-based-deployment
+scenario:
+  description: A platform engineer deploys a full environment from a software profile
+    definition alone, onto plain VMs with no pre-existing state. The software profile
+    declares the complete stack (OS, runtime, middleware, and application layers).
+    This UC validates that software profiles are sufficient for reproducible
+    deployments without manual configuration steps.
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Deploy a full environment from a software profile definition alone
+  success_criteria:
+  - Software profile definition is complete and validated
+  - Deployment proceeds from profile alone (no manual configuration)
+  - All stack layers (OS, runtime, middleware, application) are deployed
+  - Deployed environment matches the profile specification
+  - Deployment is reproducible (running it again produces identical results)
+  - Deployment events are recorded in the audit trail
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: full_stack
+    policy_complexity: single_validation
+    provider_landscape: single_eligible
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: provider
+    interaction: service provider deploys from profile specification
+  - domain: data
+    interaction: profile definition consumed; realized state recorded
+  - domain: policy
+    interaction: validation policy checks profile completeness
+  - domain: audit
+    interaction: profile-based deployment recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-30T22:00:00.000000+00:00'
+tags:
+- infrastructure
+- profile
+- deployment
+- reproducible
+- stretch
+- pipeline
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-30T22:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  author: chris@croadfeldt
+  pipeline:
+    act: 5
+    sequence: 14
+    week: wk5
+    depends_on:
+    - uc-pipeline-cp-001
+  preconditions:
+  - Software profile definition exists and is validated
+  - Target VMs are available and accessible
+  postconditions:
+  - Full environment is deployed matching the profile specification
+  - Deployment is reproducible

--- a/dav/use-cases/observability/drift-detection-remediation.yaml
+++ b/dav/use-cases/observability/drift-detection-remediation.yaml
@@ -1,0 +1,68 @@
+uuid: uc-pipeline-drift-001
+handle: observability/drift-detection-remediation
+scenario:
+  description: The drift reconciliation component compares discovered state (what actually
+    exists) against realized state (what was provisioned). When a divergence is detected,
+    a drift record is produced with field-by-field comparison and severity classification.
+    Remediation actions are triggered per recovery policy. This UC validates the operational
+    steady-state monitoring loop.
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Detect drift between discovered and realized state and remediate per recovery
+    policy
+  success_criteria:
+  - Discovered state is probed and compared against realized state
+  - Divergences produce drift records with field-by-field comparison
+  - Drift records include severity classification (info, warning, critical)
+  - Recovery policy triggers appropriate remediation actions
+  - Remediation results are recorded and verified
+  - Drift detection cycle completes within the profile-governed reconciliation window
+  dimensions:
+    lifecycle_phase: drift_detection
+    resource_complexity: single_no_deps
+    policy_complexity: single_validation
+    provider_landscape: single_eligible
+    governance_context: standard_governance
+    failure_mode: data_inconsistency
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: discovered and realized stores compared
+  - domain: policy
+    interaction: recovery policy governs remediation actions
+  - domain: provider
+    interaction: service provider executes remediation if needed
+  - domain: audit
+    interaction: drift detection and remediation recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-30T22:00:00.000000+00:00'
+tags:
+- observability
+- drift
+- detection
+- remediation
+- pipeline
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-30T22:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  author: chris@croadfeldt
+  pipeline:
+    act: 3
+    sequence: 9
+    week: wk4
+    depends_on:
+    - uc-pipeline-composite-001
+    - uc-pipeline-4state-001
+  preconditions:
+  - Composite service is realized with all constituents operational
+  - Four-state stores are populated
+  - Drift reconciliation component is active
+  postconditions:
+  - Drift between discovered and realized states is detected and classified
+  - Remediation actions have been executed per recovery policy

--- a/dav/use-cases/observability/rehydration-rto-measurement.yaml
+++ b/dav/use-cases/observability/rehydration-rto-measurement.yaml
@@ -1,0 +1,62 @@
+uuid: uc-pipeline-rto-001
+handle: observability/rehydration-rto-measurement
+scenario:
+  description: After a dynamic rehydration, the system measures recovery time objective
+    (RTO) and validates completeness. Every resource in the original intent must exist
+    in the rebuilt realized state with matching field values. The RTO measurement is
+    the time from destroy trigger to last resource reaching OPERATIONAL status.
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Measure RTO and validate completeness after dynamic rehydration
+  success_criteria:
+  - RTO is measured from destroy trigger to last resource reaching OPERATIONAL
+  - Every resource in the original intent exists in the rebuilt realized state
+  - Field values in the rebuilt realized state match the original intent (within tolerance
+    for provider-assigned fields)
+  - Completeness percentage is calculated and reported
+  - RTO measurement and completeness results are recorded in the audit trail
+  dimensions:
+    lifecycle_phase: rehydration_faithful
+    resource_complexity: full_stack
+    policy_complexity: no_policy
+    provider_landscape: multi_eligible
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: intent vs rebuilt realized compared for completeness
+  - domain: observability
+    interaction: RTO measured and reported
+  - domain: audit
+    interaction: RTO and completeness recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: seed-1.0
+  timestamp: '2026-06-30T22:00:00.000000+00:00'
+tags:
+- observability
+- rehydration
+- rto
+- measurement
+- pipeline
+version: 1.0.0
+metadata:
+  admitted_at: '2026-06-30T22:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  author: chris@croadfeldt
+  pipeline:
+    act: 4
+    sequence: 12
+    week: wk4
+    depends_on:
+    - uc-pipeline-rehydrate-001
+  preconditions:
+  - Dynamic rehydration has completed
+  - All resources are re-realized
+  postconditions:
+  - RTO is measured and recorded
+  - Completeness is verified (intent matches rebuilt realized)

--- a/dav/use-cases/observability/telemetry-export-capability.yaml
+++ b/dav/use-cases/observability/telemetry-export-capability.yaml
@@ -1,0 +1,55 @@
+uuid: uc-telemetry-export-capability
+handle: observability/telemetry-export-capability
+version: 1.0.0
+scenario:
+  description: 'Validation UC for A9: confirm DCM provides the universal telemetry-export capability —
+    a single UDLM-modeled, schema-discoverable export surface over standard transports (OTLP / Prometheus
+    / message-bus) with per-subscriber authorization and data-classification scoping, and no DCM-side
+    per-tool adapters.'
+  actor:
+    persona: platform-operator
+    profile: standard
+  intent: Validate DCM exposes one UDLM export surface over standard transports with per-subscriber policy
+  success_criteria:
+  - DCM exposes a single export/discovery surface consumable over standard transports (OTLP/Prometheus/bus)
+  - Schemas are discoverable by a consumer at subscription time (no out-of-band agreement)
+  - Export scope is policy-evaluated per subscriber (authorization + data classification)
+  - A second consuming tool attaches via the same path with no export-side change
+  - No DCM-side per-tool integration adapter is required
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: composite_service
+    policy_complexity: multi_policy_chain
+    provider_landscape: multiple_eligible
+    governance_context: audit_heavy
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: provider
+    interaction: information provider serves export/discovery over standard transports; message bus delivers
+      events
+  - domain: policy
+    interaction: per-subscriber authorization and data-classification scoping evaluated
+  - domain: data
+    interaction: telemetry exposed as UDLM-modeled discoverable data
+  - domain: audit
+    interaction: subscription and export access recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: trifecta-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- a9
+- observability
+- capability-validation
+- trifecta
+- standard-profile
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt
+  note: trifecta validation UC (Piotr-feedback DRs)

--- a/dav/use-cases/observability/telemetry-udlm-data-model.yaml
+++ b/dav/use-cases/observability/telemetry-udlm-data-model.yaml
@@ -1,0 +1,52 @@
+uuid: uc-telemetry-udlm-data-model
+handle: observability/telemetry-udlm-data-model
+version: 1.0.0
+scenario:
+  description: 'Validation UC for A9: confirm UDLM models the telemetry-export data — metrics, lifecycle/drift/policy
+    events, log records, and audit records as UDLM-modeled, schema-discoverable entities, plus a published
+    event catalog vocabulary for the curated event stream.'
+  actor:
+    persona: platform-operator
+    profile: standard
+  intent: Validate UDLM models telemetry/events/audit as schema-discoverable data + event catalog
+  success_criteria:
+  - Metrics, events, log records, and audit records are modeled as UDLM entities
+  - Schemas for those entities are discoverable (machine-readable) by consumers
+  - A published event-catalog vocabulary is modeled for the curated event stream
+  - Data-classification and tenancy are modeled on telemetry for per-subscriber scoping
+  - Retention governance for exported telemetry is representable
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: composite_service
+    policy_complexity: system_defaults_only
+    provider_landscape: multiple_eligible
+    governance_context: audit_heavy
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: telemetry/events/audit modeled as schema-discoverable UDLM entities + event catalog
+  - domain: policy
+    interaction: data-classification + retention modeled for scoping
+  - domain: audit
+    interaction: export access representable
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: trifecta-1.0
+  timestamp: '2026-06-29T00:00:00.000000+00:00'
+tags:
+- a9
+- observability
+- data-model-validation
+- trifecta
+- udlm
+- standard-profile
+metadata:
+  admitted_at: '2026-06-29T00:00:00.000000+00:00'
+  admitted_dcm_version: preview
+  promoted_from_run: null
+  initial_baseline_path: null
+  author: chris@croadfeldt
+  note: trifecta validation UC (Piotr-feedback DRs)


### PR DESCRIPTION
<!-- uc-header -->
> **UC map** — Realizes **UC-10, UC-12, UC-14–UC-21** (expanded validation corpus — the "done" evidence).

## What
Adds the remainder of the DCM validation use-case corpus developed upstream (31 new use-cases across compute, cross-domain, governance, identity, infrastructure, observability) — tenancy isolation, brownfield adoption, composite-service provision, audit-chain proofs, policy resolution, connected delegation, bare-metal/cluster bootstrap, dynamic rehydration, drift detection, telemetry export.

## Dependency
Additive on top of **#65** (initial corpus import). Kept as a separate slice so #65's in-flight review threads stay undisturbed; merges after #65.

DCO signed-off.