### PR TITLE
ci: adopt Spectral/AEP OpenAPI linting

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,0 +1,23 @@
+---
+name: OpenAPI
+on:  # yamllint disable-line rule:truthy
+  push:
+  pull_request:
+
+jobs:
+  check-aep-compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Install Spectral
+        run: npm i @stoplight/spectral-cli -g
+      - name: Lint OpenAPI schemas against AEP guidelines
+        run: |
+          shopt -s nullglob
+          files=(schemas/openapi/*.yaml api/*.yaml)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No OpenAPI schemas present yet — the AEP gate activates once schemas/openapi/ lands (#81–#83)."
+          else
+            spectral lint -r .spectral.yaml "${files[@]}"
+          fi

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,5 @@
+# AEP OpenAPI linting ruleset for the DCM API schemas. Carried forward from the original
+# object/API first draft (dcm #18, @Fale) — that PR graduated into the structured schemas/
+# suite (#81–#89); this keeps its Spectral/AEP gate so the successor schemas stay AEP-conformant.
+extends:
+  - https://raw.githubusercontent.com/aep-dev/aep-openapi-linter/main/spectral.yaml


### PR DESCRIPTION
<!-- uc-header -->
> **UC map** — Cross-cutting (CI / tooling) — supports every UC, gates none. Adds Spectral + AEP OpenAPI linting to CI so all DCM API surfaces stay AEP-conformant as they evolve; part of the AEP-adoption workstream (`adr-aep-alignment`).

Carries forward the durable piece of #18 (@Fale) — the Spectral gate linting the API against the AEP OpenAPI guidelines — as the rest of that draft graduated into the structured schemas/spec suite (#81–#89). Retargets the lint from the old `api/interoperabilityAPI.yaml` to `schemas/openapi/*.yaml` (guarded so it stays green until those schemas land), and discharges the standing AEP-adoption ask (also open on udlm #18). Lets us close #18 without losing its linter.
