### PR TITLE
docs(flows): the 21 FF-Extended use-case flows (DCM play) + persona index

### DIFF
--- a/docs/flows/README.md
+++ b/docs/flows/README.md
@@ -34,9 +34,12 @@ and *references* the shared steps (assemble, place, enrich, reserve, converge) r
 them, so each use-case flow stays short and specific to what makes that case different. Read
 request-realization first.
 
-**Planned** (same shape): the 21 September-release use cases (each labeled by its Use Case number, grouped by
-persona) · decommission & teardown ordering · drift detection → reconcile · rehydration (faithful /
-provider-portable) · dependency brokering (fulfillment: provider).
+**The 21 September-release use cases** (DAV set 29 — *FF Extended Target*) are documented as flows here, each
+labeled by its Use Case number and built on request-realization. Grouped by persona in
+**[by-persona.md](by-persona.md)** — the usage-by-role view.
+
+**Planned** (same shape): decommission & teardown ordering · drift detection → reconcile · rehydration
+(faithful / provider-portable) · dependency brokering (fulfillment: provider).
 
 ---
 

--- a/docs/flows/by-persona.md
+++ b/docs/flows/by-persona.md
@@ -1,0 +1,43 @@
+# Flows by persona — how each role uses the system
+
+**What this settles:** the 21 September-release use cases (DAV set 29, *FF Extended Target*), grouped by the
+**persona** who drives them — a usage view of the system, one role at a time. Every entry is a **lighter**
+flow that builds on [request-realization](request-realization.md); read that first. Each flow has a
+**stage** (in croadfeldt/udlm — the model's telling) and a **play** (in croadfeldt/dcm — the engine's
+telling); the links below resolve to the docs in *this* repo.
+
+## application-team-member — request and consume resources
+The everyday consumer: asks for what they need in portable terms and lets the system realize it.
+- [UC-01 · Standard VM provision](uc-01-vm-standard-provision.md)
+- [UC-02 · VM intent onto OSAC](uc-02-vm-intent-osac-placement.md)
+- [UC-03 · Persistent volume with attach](uc-03-persistent-volume-provision.md)
+- [UC-04 · VM provision, provider fails mid-realization](uc-04-vm-provision-with-provider-failure.md)
+- [UC-05 · Idempotent reconvergence](uc-05-idempotent-reconvergence.md)
+
+## platform-operator — model, register, and operate the estate
+Runs the substrate: models resources and their dependency graph, registers providers, keeps ordering sound.
+- [UC-06 · VM as a first-class resource](uc-06-vm-resource-representation.md)
+- [UC-07 · Dependency graph as first-class data](uc-07-udlm-dependency-graph-data-model.md)
+- [UC-08 · Cross-provider ordering](uc-08-cross-provider-dependency-ordering.md)
+- [UC-09 · Broken dependency, surfaced](uc-09-dependency-failure-impact.md)
+- [UC-10 · Provider registration + capability](uc-10-provider-registration-capability.md)
+
+## platform-engineer — day-2: rehydration, drift, policy, profiles
+Owns the running system: recovery, drift, policy overrides, and how profiles resolve.
+- [UC-11 · Policy override approval](uc-11-policy-override-approval.md)
+- [UC-12 · Dynamic rehydration](uc-12-dynamic-rehydration.md)
+- [UC-13 · Rehydration RTO measurement](uc-13-rehydration-rto-measurement.md)
+- [UC-14 · Drift detection & remediation](uc-14-drift-detection-remediation.md)
+- [UC-15 · Provider-portable rebuild](uc-15-provider-portable-rebuild.md)
+- [UC-16 · Policy resolution by profile](uc-16-policy-resolution-capability.md)
+- [UC-17 · Profile resolution & atomic onboarding](uc-17-profile-resolution-capability.md)
+
+## compliance-auditor / auditor — provenance and cryptographic audit
+Verifies what happened: field-level provenance and tamper-evident proofs.
+- [UC-18 · Realized status with field-level provenance](uc-18-vm-status-provenance.md)
+- [UC-19 · Cryptographic audit verification](uc-19-audit-merkle-tree-verification.md)
+- [UC-20 · Transparency-log capability validation](uc-20-audit-chain-proofs-capability.md)
+
+## solution-architect — decompose an architecture into resources
+Turns a whole architecture into ordered, dependency-aware resource requests.
+- [UC-21 · Solution architecture deployment](uc-21-solution-architecture-deployment.md)

--- a/docs/flows/request-realization.md
+++ b/docs/flows/request-realization.md
@@ -1,7 +1,7 @@
 # Request realization — the play
 
 **Purpose:** how DCM runs a request from portable intent to a built resource — the components, the sequence,
-and what an engineer has to build. The worked example is Ondra's: a user asks for a VM with cpu + memory,
+and what an engineer has to build. The worked example: a user asks for a VM with cpu + memory,
 the system picks OpenShift, and OpenShift needs a `namespace` the request never carried. This flow shows
 exactly where that value comes from. It performs the model staged in
 [udlm `docs/flows/request-realization.md`](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md);

--- a/docs/flows/uc-01-vm-standard-provision.md
+++ b/docs/flows/uc-01-vm-standard-provision.md
@@ -1,0 +1,47 @@
+# UC-01 · Standard VM provision — the play
+
+**Purpose:** how DCM runs the plainest case — standard profile, one eligible provider, one policy check — on
+top of [request-realization](request-realization.md). The only mechanics this UC adds are the
+**pre-allocation policy gate** and the **audit record**; the base pipeline (assemble/place/enrich/reserve/commit)
+lives there.
+
+> **Use Case:** `compute/vm-standard-provision` · **Persona:** application-team-member.
+
+## What's different in the engine
+- **Placement has one candidate.** `provider_landscape: single_eligible` — the policy engine still runs
+  placement, but the eligible set has one member. No scoring to speak of.
+- **Policy gate before allocation.** The resolved standard-profile policy set (`single_validation`) is
+  evaluated before reserve. Pass → proceed; fail → stop with a field-level policy error, nothing allocated.
+- **Audit write is part of done.** On commit, DCM writes an audit event carrying **actor · intent · outcome** —
+  a required outcome here, not an incidental log line.
+- **Idempotency** is guaranteed but implemented by the reconvergence path — see [UC-05](uc-05-idempotent-reconvergence.md).
+
+## Sequence — only the UC-specific part
+```mermaid
+sequenceDiagram
+    actor User
+    participant Pol as Policy engine
+    participant Disp as Dispatcher
+    participant Prov as VM provider
+    participant Aud as Audit store
+
+    User->>Pol: standard-profile VM intent
+    Pol->>Pol: evaluate resolved-profile policies (single validation)
+    alt policy passes
+        Pol->>Disp: reserve then commit (single eligible provider)
+        Disp->>Prov: commit
+        Prov-->>Disp: built + native id
+        Disp->>Aud: record actor, intent, outcome
+        Disp->>User: created
+    else policy fails
+        Pol->>User: rejected — clear policy error, nothing allocated
+    end
+```
+
+## What an engineer adds
+- The **standard profile's resolved policy set** (the single validation that must pass pre-allocation).
+- The **audit binding** — actor · intent · outcome written on the realization event.
+- Nothing new for assembly, placement, or reserve/commit — those are the base engine.
+
+## Pointers
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `compute/vm-standard-provision`.

--- a/docs/flows/uc-02-vm-intent-osac-placement.md
+++ b/docs/flows/uc-02-vm-intent-osac-placement.md
@@ -1,0 +1,45 @@
+# UC-02 · VM intent onto OSAC — the play
+
+**Purpose:** how DCM places a VM intent onto an **OSAC-backed provider** on top of
+[request-realization](request-realization.md) — proving OSAC participates through the ordinary provider
+contract, with DCM as the control plane. Only the OSAC-specific mechanics are here; the base pipeline lives in
+request-realization.
+
+> **Use Case:** `compute/vm-intent-osac-placement` · **Persona:** application-team-member.
+
+## What's different in the engine
+- **OSAC is a registered provider.** It appears in the provider registry with its required-data like any
+  other. Placement selecting it is the ordinary selection step, not a special integration.
+- **Validation gates before placement.** A single gating policy runs before the placement engine selects
+  (`policy_complexity: single_gating`).
+- **Provenance names OSAC.** On commit, DCM records the `Realized` state with provider provenance identifying
+  the OSAC-backed provider — a checked outcome, not just a log.
+- **Dispatch is the standard reserve→commit** against the OSAC provider adapter.
+
+## Sequence — only the UC-specific part
+```mermaid
+sequenceDiagram
+    actor User
+    participant API as DCM API
+    participant Pol as Policy engine
+    participant Reg as Provider registry
+    participant Disp as Dispatcher
+    participant OSAC as OSAC provider
+
+    User->>API: VM workload intent
+    API->>Pol: validate (single gating) then place
+    Pol->>Reg: eligible providers for this VM
+    Reg-->>Pol: OSAC-backed provider
+    Pol->>Disp: dispatch to OSAC (reserve then commit)
+    Disp->>OSAC: reserve then commit
+    OSAC-->>Disp: built + native id
+    Disp->>User: realized, provenance OSAC
+```
+
+## What an engineer adds
+- **OSAC provider registration** — its required-data and adapter, so placement can select and dispatch to it.
+- **The gating validation policy** that must pass before placement.
+- **Provenance capture** wiring OSAC's identity into the `Realized` record. No changes to the base pipeline.
+
+## Pointers
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `compute/vm-intent-osac-placement`.

--- a/docs/flows/uc-03-persistent-volume-provision.md
+++ b/docs/flows/uc-03-persistent-volume-provision.md
@@ -1,0 +1,48 @@
+# UC-03 · Persistent volume with attach — the play
+
+**Purpose:** how DCM provisions a block volume **and attaches it to an existing VM** on top of
+[request-realization](request-realization.md). The new mechanics are the cross-resource reference, the
+tenant-isolation gate on storage class, the two provider calls, and quota accounting; the base pipeline lives
+in request-realization.
+
+> **Use Case:** `data/persistent-volume-provision` · **Persona:** application-team-member.
+
+## What's different in the engine
+- **A dependency in the payload.** The request carries a reference to an existing `Compute.VirtualMachine`
+  (`resource_complexity: cross_dependency_payload`). Placement and reserve must resolve that reference before
+  the volume can be attached.
+- **Tenant-isolation gate.** A gating policy checks the request against the tenant's storage-class eligibility
+  before allocation — and the attach must not expose the volume across tenants.
+- **Two provider interactions.** The storage provider allocates the volume; a service provider attaches it to
+  the VM. Reserve confirms both are satisfiable before either commits.
+- **Quota decrement.** On commit, the tenant's quota is updated and the volume record is written with tenancy
+  and the VM reference.
+
+## Sequence — only the UC-specific part
+```mermaid
+sequenceDiagram
+    actor User
+    participant Pol as Policy engine
+    participant Disp as Dispatcher
+    participant Store as Storage provider
+    participant Svc as VM service provider
+    participant Data as State + quota store
+
+    User->>Pol: volume intent, references existing VM
+    Pol->>Pol: tenant-isolation gate on storage-class eligibility
+    Pol->>Disp: reserve volume and attach (both must hold)
+    Disp->>Store: commit — allocate volume in eligible class
+    Store-->>Disp: volume + native id
+    Disp->>Svc: attach volume to target VM (no cross-tenant exposure)
+    Svc-->>Disp: attached
+    Disp->>Data: write volume record with tenancy and VM ref, decrement quota
+    Disp->>User: created and attached
+```
+
+## What an engineer adds
+- **The tenant-isolation policy** gating storage-class eligibility (and any data-residency constraint).
+- **Storage + attach provider registrations** with their required-data.
+- **Quota accounting** wired to the commit, and the volume record's tenancy + VM reference.
+
+## Pointers
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `data/persistent-volume-provision`.

--- a/docs/flows/uc-04-vm-provision-with-provider-failure.md
+++ b/docs/flows/uc-04-vm-provision-with-provider-failure.md
@@ -1,0 +1,49 @@
+# UC-04 · VM provision, provider fails mid-realization — the play
+
+**Purpose:** how DCM recovers when a provider **accepts the dispatch then goes unreachable** — on top of
+[request-realization](request-realization.md). Everything through dispatch is the base pipeline; the new
+mechanics are timeout detection, the recovery policy, and clean reconciliation of partial state.
+
+> **Use Case:** `compute/vm-provision-with-provider-failure` · **Persona:** application-team-member.
+
+## What's different in the engine
+- **A dispatch timeout bounds the wait.** The dispatcher detects unreachability within the timeout rather than
+  hanging on a pending commit.
+- **A recovery policy decides.** It classifies the partial-realization state and picks **requeue / hold /
+  fail** (`policy_complexity: recovery_policy`). The decision is audit-recorded.
+- **Multiple eligible providers.** `provider_landscape: multiple_eligible` — so requeue onto an alternate is a
+  real path when policy permits.
+- **No orphaned state.** Partial allocations are reconciled to complete or cleanly released; the requested
+  state never shows an indeterminate resource without a matching recovery record.
+
+## Sequence — only the UC-specific part
+```mermaid
+sequenceDiagram
+    participant Disp as Dispatcher
+    participant P1 as Primary provider
+    participant Rec as Recovery policy
+    participant P2 as Alternate provider
+    participant Aud as Audit store
+
+    Disp->>P1: commit
+    P1-->>Disp: accepted, then unreachable
+    Disp->>Disp: detect unreachability within dispatch timeout
+    Disp->>Rec: classify partial-realization state
+    alt requeue
+        Rec->>P2: dispatch to alternate eligible provider
+        P2-->>Disp: built + native id
+    else hold
+        Rec->>Disp: hold pending provider recovery
+    else fail
+        Rec->>Disp: release partial allocations, fail request
+    end
+    Disp->>Aud: record detection, decision, and final outcome with provider ids
+```
+
+## What an engineer adds
+- **The recovery policy** — classification of partial state plus the requeue / hold / fail decision rules.
+- **A dispatch timeout** on the provider adapter, and the reconcile/release path for partial allocations.
+- **Recovery-record + audit** capture, naming both provider identities.
+
+## Pointers
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `compute/vm-provision-with-provider-failure`.

--- a/docs/flows/uc-05-idempotent-reconvergence.md
+++ b/docs/flows/uc-05-idempotent-reconvergence.md
@@ -1,0 +1,44 @@
+# UC-05 · Idempotent reconvergence — the play
+
+**Purpose:** how DCM turns a re-applied, unchanged intent into a **no-op** — on top of
+[request-realization](request-realization.md). The only new mechanic is the intent-vs-realized compare that
+short-circuits before dispatch; the base pipeline lives in request-realization.
+
+> **Use Case:** `compute/idempotent-reconvergence` · **Persona:** application-team-member.
+
+## What's different in the engine
+- **A modification, not a new request.** `lifecycle_phase: modification` — the resource already exists and the
+  four-state stores are populated.
+- **Compare before dispatch.** After validation, DCM compares the incoming intent against the current realized
+  state. Equal → short-circuit: no reserve, no commit, no provider call.
+- **Stable identity.** Resource UUIDs are not reassigned on a no-op.
+- **The no-op is audited.** The decision and its rationale ("realized already matches intent") are recorded.
+- On a **mismatch**, DCM falls through to the ordinary request-realization pipeline.
+
+## Sequence — only the UC-specific part
+```mermaid
+sequenceDiagram
+    actor User
+    participant Pol as Policy engine
+    participant Data as Four-state store
+    participant Aud as Audit store
+
+    User->>Pol: re-apply unchanged intent
+    Pol->>Pol: validation policy
+    Pol->>Data: compare intent against realized state
+    alt realized already matches
+        Data-->>Pol: match — no change
+        Pol->>Aud: record no-op decision and rationale
+        Pol->>User: no-op, UUIDs stable, no dispatch
+    else differs
+        Pol->>User: fall through to request-realization
+    end
+```
+
+## What an engineer adds
+- **The intent-vs-realized equivalence check** that gates dispatch (and defines what "unchanged" means).
+- **The no-op audit record** — decision plus rationale.
+- Nothing else — the mismatch path reuses the base pipeline unchanged.
+
+## Pointers
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `compute/idempotent-reconvergence`.

--- a/docs/flows/uc-06-vm-resource-representation.md
+++ b/docs/flows/uc-06-vm-resource-representation.md
@@ -1,0 +1,38 @@
+# UC-06 · VM as a first-class resource — the play
+
+**Purpose:** how DCM runs this case, on top of [request-realization](request-realization.md) — only the UC-specific mechanics. Here that's the registration of the `Compute.VirtualMachine` type and the reconciliation of libvirt's realized status back onto the resource.
+
+> **Use Case:** `libvirt-vm-provider/standard/vm-resource-representation` · **Persona:** platform-operator.
+
+## What's different in the engine
+
+- **Type registration, then instances.** Before any request, the platform-operator registers the `Compute.VirtualMachine` type (spec schema + status schema) in the resource registry. request-realization then runs unchanged for each instance.
+- **Status reconciliation loop.** After commit, the libvirt provider reports realized facts; DCM writes them to the resource's status subresource and keeps them reconciled on drift — the piece request-realization only records once at commit.
+- **One record, two sides.** Spec (asked) and status (built) are stored on the same resource so `GET` returns both.
+
+## Sequence — only the UC-specific part
+
+```mermaid
+sequenceDiagram
+    actor Op as Platform-operator
+    participant Reg as Resource registry
+    participant RR as request-realization
+    participant Lv as libvirt provider
+    participant St as State store
+
+    Op->>Reg: register Compute.VirtualMachine (spec + status schema)
+    Op->>RR: submit VM intent
+    RR->>Lv: reserve then commit (see base flow)
+    Lv-->>St: realized status — host, disks, power state
+    St->>St: reconcile status onto the same resource
+    Note over St: GET returns spec asked and status built
+```
+
+## What an engineer adds
+
+- The `Compute.VirtualMachine` spec and status schemas at registration time.
+- A status-reconcile handler that maps libvirt native facts onto the resource's status subresource — nothing else in the base flow changes.
+
+## Pointers
+
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `libvirt-vm-provider/standard/vm-resource-representation`.

--- a/docs/flows/uc-07-udlm-dependency-graph-data-model.md
+++ b/docs/flows/uc-07-udlm-dependency-graph-data-model.md
@@ -1,0 +1,38 @@
+# UC-07 · Dependency graph as first-class data — the play
+
+**Purpose:** how DCM runs this case, on top of [request-realization](request-realization.md) — only the UC-specific mechanics. Here that's reading ordering and impact *out of* the UDLM graph rather than maintaining a separate dependency map.
+
+> **Use Case:** `dcm-core/standard/udlm-dependency-graph-data-model` · **Persona:** platform-operator.
+
+## What's different in the engine
+
+- **No parallel dependency store.** DCM queries the UDLM graph directly for the three edge kinds — containment, `depends_on`, shares-fault-domain — instead of building its own.
+- **Two derived reads, one source.** A topological sort over `depends_on` + containment yields convergence order; a reverse-reachability walk over the same edges yields blast-radius and redundancy.
+- **Edges written where they're known.** Containment and fault-domain edges are recorded at realization (which host, which pool); `depends_on` edges come from the resource spec.
+
+## Sequence — only the UC-specific part
+
+```mermaid
+sequenceDiagram
+    actor Op as Platform-operator
+    participant G as UDLM graph
+    participant Ord as Ordering query
+    participant Imp as Impact query
+
+    Op->>G: realize resources, record edges (containment, depends_on, fault-domain)
+    Op->>Ord: what order is safe?
+    Ord->>G: topological sort over depends_on + containment
+    G-->>Ord: convergence order
+    Op->>Imp: what falls if this node fails?
+    Imp->>G: reverse-reachability over the same edges
+    G-->>Imp: blast-radius and surviving redundancy
+```
+
+## What an engineer adds
+
+- Population of the three edge kinds as resources realize — no separate ordering table.
+- Two graph queries (topological sort, reverse-reachability) that read the UDLM graph as their only source of truth.
+
+## Pointers
+
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `dcm-core/standard/udlm-dependency-graph-data-model`.

--- a/docs/flows/uc-08-cross-provider-dependency-ordering.md
+++ b/docs/flows/uc-08-cross-provider-dependency-ordering.md
@@ -1,0 +1,38 @@
+# UC-08 · Cross-provider ordering — the play
+
+**Purpose:** how DCM runs this case, on top of [request-realization](request-realization.md) — only the UC-specific mechanics. Here that's sequencing convergence across provider boundaries from the `depends_on` graph, with a gate that blocks on unrealized prerequisites.
+
+> **Use Case:** `libvirt-vm-provider/standard/cross-provider-dependency-ordering` · **Persona:** platform-operator.
+
+## What's different in the engine
+
+- **An orchestrator over per-resource realization.** DCM topologically sorts the `depends_on` graph (UC-07) and dispatches each resource's request-realization in order — even when prerequisite and dependent have different owning providers.
+- **A readiness gate, not a skip.** Before dispatching the VM, DCM checks the bridge is Realized. Not yet — it blocks and re-checks; it never proceeds without the prerequisite.
+- **Reverse on teardown.** The same sort, reversed: dependents down before prerequisites.
+
+## Sequence — only the UC-specific part
+
+```mermaid
+sequenceDiagram
+    actor Op as Platform-operator
+    participant Orc as Orchestrator
+    participant Net as Network/host provider
+    participant Lv as libvirt provider
+
+    Op->>Orc: converge VM (depends_on host bridge)
+    Orc->>Net: realize the bridge first
+    Net-->>Orc: bridge Realized
+    Orc->>Orc: gate passes, bridge is ready
+    Orc->>Lv: realize the VM (request-realization)
+    Lv-->>Orc: VM Realized
+    Note over Orc: teardown reverses — VM down before bridge
+```
+
+## What an engineer adds
+
+- A topological dispatcher over the `depends_on` graph that spans providers.
+- A prerequisite-readiness gate that blocks (and re-checks) rather than skips, plus the reverse ordering for teardown.
+
+## Pointers
+
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `libvirt-vm-provider/standard/cross-provider-dependency-ordering`.

--- a/docs/flows/uc-09-dependency-failure-impact.md
+++ b/docs/flows/uc-09-dependency-failure-impact.md
@@ -1,0 +1,38 @@
+# UC-09 · Broken dependency, surfaced — the play
+
+**Purpose:** how DCM runs this case, on top of [request-realization](request-realization.md) — only the UC-specific mechanics. Here that's turning an absent prerequisite into a named, blocking, escalated unmet edge with a derivable blast-radius.
+
+> **Use Case:** `libvirt-vm-provider/standard/dependency-failure-impact` · **Persona:** platform-operator.
+
+## What's different in the engine
+
+- **Unmet-edge detection at the gate.** The UC-08 readiness gate, when the prerequisite can't be resolved, produces a specific diagnostic — which edge, which target — rather than a generic reserve failure.
+- **Block and escalate.** Policy here is `human_escalation_required`: DCM holds the VM and raises the unmet edge to an operator instead of retrying blindly or building anyway.
+- **Impact from the graph.** A reverse-reachability query over the same edges (UC-07) answers "what else needs `br0`" so the operator sees the blast-radius, not just the one VM.
+
+## Sequence — only the UC-specific part
+
+```mermaid
+sequenceDiagram
+    actor Op as Platform-operator
+    participant Orc as Orchestrator
+    participant Lv as libvirt provider
+    participant G as UDLM graph
+
+    Op->>Orc: converge VM (nic0 depends_on br0)
+    Orc->>Lv: reserve the VM
+    Lv-->>Orc: br0 absent — cannot attach nic0
+    Orc->>Orc: flag unmet edge nic0 to br0, block convergence
+    Orc->>G: what else depends on br0?
+    G-->>Orc: blast-radius set
+    Orc->>Op: escalate — named unmet edge plus impact
+```
+
+## What an engineer adds
+
+- A diagnostic path that maps a provider "prerequisite absent" into a named unmet edge and escalates it.
+- Reuse of the UC-07 reverse-reachability query to attach blast-radius to the escalation — no new impact store.
+
+## Pointers
+
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `libvirt-vm-provider/standard/dependency-failure-impact`.

--- a/docs/flows/uc-10-provider-registration-capability.md
+++ b/docs/flows/uc-10-provider-registration-capability.md
@@ -1,0 +1,39 @@
+# UC-10 · Provider registration + capability — the play
+
+**Purpose:** how DCM runs this case, on top of [request-realization](request-realization.md) — only the UC-specific mechanics. Here that's the libvirt provider registering capability and per-host capacity into the registry that placement reads.
+
+> **Use Case:** `libvirt-vm-provider/standard/provider-registration-capability` · **Persona:** platform-operator.
+
+## What's different in the engine
+
+- **Registration populates the provider registry.** The libvirt provider registers, advertising the `compute/virtual-machine` capability and per-host cpu/memory/storage capacity — the registry request-realization's Place step already consults.
+- **Capacity is placement input, not just metadata.** Placement filters to providers with the capability, then to hosts with room for the intent's cpu/memory/storage, then selects.
+- **No change downstream.** Once a provider+host is selected, enrich/reserve/commit are exactly the base flow.
+
+## Sequence — only the UC-specific part
+
+```mermaid
+sequenceDiagram
+    actor Op as Platform-operator
+    participant Lv as libvirt provider
+    participant Reg as Provider registry
+    participant Pol as Policy engine
+
+    Op->>Lv: bring provider online
+    Lv->>Reg: register — capability compute/virtual-machine
+    Lv->>Reg: publish per-host capacity (cpu, memory, storage)
+    Note over Op,Pol: later, a VM intent arrives
+    Pol->>Reg: which providers serve compute/virtual-machine with room?
+    Reg-->>Pol: eligible providers and hosts with capacity
+    Pol->>Pol: select provider + host, then base flow continues
+```
+
+## What an engineer adds
+
+- The provider's registration payload — capability set plus per-host capacity, kept current as hosts fill.
+- A placement filter that matches capability then fits capacity to a host; the rest of request-realization is unchanged.
+
+## Pointers
+
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `libvirt-vm-provider/standard/provider-registration-capability`.
+- Registration mechanics: `docs/specifications/dcm-registration-spec.md`.

--- a/docs/flows/uc-11-policy-override-approval.md
+++ b/docs/flows/uc-11-policy-override-approval.md
@@ -1,0 +1,52 @@
+# UC-11 · Policy override approval — the play
+
+**Purpose:** how DCM runs a time-bounded policy override on top of
+[request-realization](request-realization.md) — only the UC-specific mechanics.
+
+> **Use Case:** `governance/policy-override-approval` · **Persona:** platform-engineer.
+
+## What's different in the engine
+- **A failing soft policy opens a path, not a dead end.** When the policy engine returns a soft-enforcement
+  failure, the engineer can file an `override_request` carrying the matched scope, a requested duration, and a
+  rationale. This is a modification to the policy-application state, not a new resource.
+- **Eligibility read from the policy artifact itself.** The engine reads the target policy's declared
+  override rules. Hard-enforcement policies declare no override path, so the request is rejected before any
+  approver is contacted.
+- **Approval routed by class.** An orchestration/approval policy maps the override class to the authorized
+  approver role and routes there — never back to the requester. The engine waits on the human decision.
+- **Grant recorded, then honored on re-evaluation.** A granted override is persisted (scope, duration,
+  approver, rationale). Subsequent evaluations of the matched scope consult active overrides; a suppressed
+  event is written with a link back to the grant so audit can reconstruct what it let through.
+
+## Sequence — only the UC-specific part
+```mermaid
+sequenceDiagram
+    actor Eng as Platform engineer
+    participant Pol as Policy engine
+    participant OR as Override workflow
+    participant Appr as Authorized approver
+    participant Aud as Audit store
+
+    Pol-->>Eng: soft policy FAILED — deployment blocked
+    Eng->>OR: file override_request (scope, duration, rationale)
+    OR->>Pol: read this policy's override eligibility
+    alt hard enforcement
+        Pol-->>OR: unoverridable
+        OR-->>Eng: rejected — no approval attempted
+    else eligible
+        OR->>Appr: route by override class (not the requester)
+        Appr-->>OR: grant (or deny)
+        OR->>Aud: record grant — scope, duration, approver, rationale
+        OR->>Pol: active override for matched scope
+        Pol->>Aud: suppressed event linked to the grant
+        Pol-->>Eng: matched scope now passes — deployment proceeds
+    end
+```
+
+## What an engineer adds
+- The **override-eligibility declaration** on each policy artifact (or its absence, which means hard/unoverridable).
+- The **approval-routing policy** mapping override class to approver role, and the store for override records.
+- The **audit link** from each suppressed evaluation back to the grant. Realization itself is untouched.
+
+## Pointers
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `governance/policy-override-approval`.

--- a/docs/flows/uc-12-dynamic-rehydration.md
+++ b/docs/flows/uc-12-dynamic-rehydration.md
@@ -1,0 +1,50 @@
+# UC-12 · Dynamic rehydration — the play
+
+**Purpose:** how DCM rebuilds a whole environment from stored intent, on top of
+[request-realization](request-realization.md) — only the UC-specific mechanics.
+
+> **Use Case:** `cross-domain/dynamic-rehydration` · **Persona:** platform-engineer.
+
+## What's different in the engine
+- **A planner sits in front of the normal engine.** It reads the intent store and the dependency graph and
+  produces a topological rebuild order. There is no action replay — the order is computed at rebuild time, so
+  it reflects current policy and the currently registered providers.
+- **The per-resource path is the ordinary one.** For each resource in order, DCM runs the standard
+  assemble → place → enrich → reserve → commit. Placement re-scores; sovereignty and the other validation
+  policies re-evaluate. A resource may legitimately land on a different provider than before.
+- **UUIDs are carried, not minted.** The rebuild reuses each resource's stored UUID so cross-resource
+  references resolve and the rebuilt graph is identity-stable.
+- **Ordering gates on readiness.** A dependent is only dispatched once its dependencies report realized, so the
+  graph edges become the scheduler's wait conditions.
+
+## Sequence — only the UC-specific part
+```mermaid
+sequenceDiagram
+    actor Eng as Platform engineer
+    participant Plan as Rehydration planner
+    participant Graph as Intent + dependency graph
+    participant Eng2 as Realization engine
+    participant Prov as Providers
+    participant Aud as Audit store
+
+    Eng->>Plan: rehydrate environment
+    Plan->>Graph: read intent + dependency graph
+    Graph-->>Plan: resources + edges (realized cleared)
+    Plan->>Plan: derive topological order (not a replay)
+    loop each resource in dependency order
+        Plan->>Eng2: realize resource (preserve UUID)
+        Eng2->>Eng2: re-evaluate policies incl. sovereignty, re-place
+        Eng2->>Prov: reserve then commit
+        Prov-->>Eng2: built + native id
+        Eng2->>Aud: rebuild step recorded
+    end
+    Eng2-->>Eng: realized matches original intent
+```
+
+## What an engineer adds
+- The **rehydration planner** — graph read plus topological ordering with readiness gating. The realization
+  engine, placement, and providers are reused unchanged.
+- **UUID preservation** through the realize path so identity survives the cycle. Everything else is request-realization.
+
+## Pointers
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `cross-domain/dynamic-rehydration`.

--- a/docs/flows/uc-13-rehydration-rto-measurement.md
+++ b/docs/flows/uc-13-rehydration-rto-measurement.md
@@ -1,0 +1,48 @@
+# UC-13 · Rehydration RTO measurement — the play
+
+**Purpose:** how DCM measures and validates a rehydration, on top of
+[request-realization](request-realization.md) and [UC-12](uc-12-dynamic-rehydration.md) — only the
+UC-specific mechanics.
+
+> **Use Case:** `observability/rehydration-rto-measurement` · **Persona:** platform-engineer.
+
+## What's different in the engine
+- **An observer brackets the rehydration.** It timestamps the destroy trigger and watches resource status,
+  stopping the clock when the last resource reports `OPERATIONAL`. The RTO is that interval — one number for
+  the environment.
+- **A completeness checker diffs intent against realized.** It walks every resource in the original intent,
+  confirms a matching rebuilt realized record, and compares fields. Provider-assigned fields (native ids,
+  addresses) are compared under tolerance rather than for exact equality.
+- **Results are recorded, not acted on.** RTO and the completeness percentage are written to the audit trail.
+  This UC triggers no remediation and no provider calls of its own.
+
+## Sequence — only the UC-specific part
+```mermaid
+sequenceDiagram
+    actor Eng as Platform engineer
+    participant Obs as RTO observer
+    participant RH as Rehydration (UC-12)
+    participant Chk as Completeness checker
+    participant St as Intent + realized stores
+    participant Aud as Audit store
+
+    Eng->>Obs: begin measured rehydration
+    Obs->>Obs: timestamp destroy trigger — start clock
+    Obs->>RH: run dynamic rehydration
+    RH-->>Obs: last resource OPERATIONAL
+    Obs->>Obs: stop clock — RTO computed
+    Obs->>Chk: validate completeness
+    Chk->>St: read intent and rebuilt realized
+    St-->>Chk: both states
+    Chk->>Chk: field-by-field diff (tolerance for provider-assigned)
+    Chk->>Aud: record RTO + completeness percentage
+    Aud-->>Eng: RTO and completeness reported
+```
+
+## What an engineer adds
+- The **RTO observer** (trigger timestamp plus an `OPERATIONAL` watch across all resources) and the
+  **completeness checker** with its provider-assigned-field tolerance rules.
+- The **audit write** for RTO and completeness. No changes to realization or rehydration themselves.
+
+## Pointers
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `observability/rehydration-rto-measurement`.

--- a/docs/flows/uc-14-drift-detection-remediation.md
+++ b/docs/flows/uc-14-drift-detection-remediation.md
@@ -1,0 +1,54 @@
+# UC-14 · Drift detection & remediation — the play
+
+**Purpose:** how DCM runs the steady-state drift loop, on top of
+[request-realization](request-realization.md) — only the UC-specific mechanics.
+
+> **Use Case:** `observability/drift-detection-remediation` · **Persona:** platform-engineer.
+
+## What's different in the engine
+- **A reconciliation component runs on a timer.** The profile sets the cadence and the window. Each cycle
+  probes the provider for discovered state — the actual current shape of the resource — rather than trusting
+  the realized record.
+- **A comparator produces drift records.** Discovered is diffed against realized field by field. A divergence
+  becomes a drift record carrying the per-field delta and a severity (info / warning / critical).
+- **The recovery policy chooses the action.** Keyed on severity and resource, it decides re-converge, alert,
+  or quarantine. A re-converge routes back through the ordinary realization path to bring the resource in line.
+- **Results are recorded and verified.** After remediation, the component re-probes or reads back the result,
+  records it, and confirms the drift is resolved — all inside the reconciliation window.
+
+## Sequence — only the UC-specific part
+```mermaid
+sequenceDiagram
+    participant Timer as Reconciliation timer
+    participant Rec as Drift reconciler
+    participant Prov as Provider
+    participant St as Realized store
+    participant Pol as Recovery policy
+    participant Aud as Audit store
+
+    Timer->>Rec: cycle start (profile cadence)
+    Rec->>Prov: probe discovered state
+    Prov-->>Rec: actual current state
+    Rec->>St: read realized state
+    St-->>Rec: provisioned state
+    Rec->>Rec: field-by-field diff, classify severity
+    alt diverged
+        Rec->>Aud: write drift record (fields + severity)
+        Rec->>Pol: select remediation for this drift
+        Pol-->>Rec: action
+        Rec->>Prov: execute remediation
+        Prov-->>Rec: result
+        Rec->>Aud: record and verify result (within window)
+    else match
+        Rec->>Aud: cycle recorded — no drift
+    end
+```
+
+## What an engineer adds
+- The **discovered-state probe** per provider, the **comparator + severity classifier**, and the **recovery
+  policy** mapping drift to action.
+- The **cadence and window** wiring from the profile, and the verify-after-remediate step. A re-converge reuses
+  the ordinary realization path — no new build flow.
+
+## Pointers
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `observability/drift-detection-remediation`.

--- a/docs/flows/uc-15-provider-portable-rebuild.md
+++ b/docs/flows/uc-15-provider-portable-rebuild.md
@@ -1,0 +1,50 @@
+# UC-15 · Provider-portable rebuild — the play
+
+**Purpose:** how DCM rebuilds resources on an alternate provider after a failure, on top of
+[request-realization](request-realization.md) — only the UC-specific mechanics.
+
+> **Use Case:** `cross-domain/provider-portable-rebuild` · **Persona:** platform-engineer.
+
+## What's different in the engine
+- **Provider health is a trigger.** A failed health check or an explicit deregistration marks the provider
+  unavailable and identifies the realized resources placed on it.
+- **Placement re-runs with an exclusion.** The affected resources go back through the placement engine with
+  the failed provider removed from the eligible pool. Validation policies re-evaluate against the alternate —
+  a resource may only move somewhere policy still allows.
+- **Naturalized references are re-derived.** The old provider's `provider_extensions` (namespace, native id,
+  cluster) are dropped and re-enriched for the new provider through the ordinary enrichment step. The portable
+  base of the resource is unchanged.
+- **Re-realize, then confirm portability.** The dispatcher reserves and commits on the alternate provider, and
+  the engine confirms the provider-neutral fields still match intent. The whole move is recorded.
+
+## Sequence — only the UC-specific part
+```mermaid
+sequenceDiagram
+    participant Reg as Provider registry
+    participant Rebuild as Portable-rebuild controller
+    participant Pol as Placement + policy engine
+    participant Alt as Alternate provider
+    participant St as Intent + realized stores
+    participant Aud as Audit store
+
+    Reg-->>Rebuild: provider unavailable (health / deregistration)
+    Rebuild->>St: read intent for affected resources
+    St-->>Rebuild: intent + realized
+    Rebuild->>Pol: re-place with failed provider excluded
+    Pol->>Pol: re-evaluate validation policies for alternate
+    Pol-->>Rebuild: alternate eligible provider chosen
+    Rebuild->>Rebuild: rewrite naturalized references for new provider
+    Rebuild->>Alt: reserve then commit (re-realize from intent)
+    Alt-->>Rebuild: built + new native id
+    Rebuild->>St: update realized (provider-neutral fields match intent)
+    Rebuild->>Aud: record portability event + re-resolution
+```
+
+## What an engineer adds
+- The **health/deregistration signal** and the **controller** that gathers affected resources and drives
+  re-placement with the failed provider excluded.
+- The **reference-rewrite** step that clears and re-enriches provider-specific extensions for the new provider.
+  Placement, enrichment, and the dispatcher are reused as-is.
+
+## Pointers
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `cross-domain/provider-portable-rebuild`.

--- a/docs/flows/uc-16-policy-resolution-capability.md
+++ b/docs/flows/uc-16-policy-resolution-capability.md
@@ -1,0 +1,47 @@
+# UC-16 · Policy resolution by profile — the play
+
+**Purpose:** how DCM decides which policies apply and reports them honestly, on top of
+[request-realization](request-realization.md) — only the UC-specific mechanics. Validation UC for **DR-E**.
+
+> **Use Case:** `governance/policy-resolution-capability` · **Persona:** platform-engineer.
+
+## What's different in the engine
+- **Profile resolution comes first.** The engine resolves the request's profile — an approved-list selection
+  or the platform default — before any policy runs. That resolved profile *is* the policy set, selected by
+  construction rather than filtered from a global registry at runtime.
+- **Evaluation is closed to the profile.** Only the profile's policies are evaluated. There is no global
+  fall-through path that could reach a policy outside it.
+- **Outcomes are three-state.** Each policy result is recorded as evaluated-pass, evaluated-fail, or
+  out-of-scope. Out-of-scope is a first-class outcome for policies not in the resolved profile — it is never
+  collapsed into a soft-pass.
+- **The audit is the honest ledger.** The policies-evaluated list carries all three states so a reviewer can
+  distinguish "did not apply" from "applied and passed".
+
+## Sequence — only the UC-specific part
+```mermaid
+sequenceDiagram
+    actor Eng as Platform engineer
+    participant Res as Profile resolver
+    participant Pol as Policy engine
+    participant St as Request store
+    participant Aud as Audit store
+
+    Eng->>Res: submit request
+    Res->>Res: resolve profile (approved-list or platform default)
+    Res->>St: store resolved profile + its policy set
+    Res->>Pol: evaluate only this profile's policies
+    Pol->>Pol: run each in-scope policy
+    Pol->>Aud: record evaluated-pass / evaluated-fail per policy
+    Pol->>Aud: record out-of-scope for policies not in the profile
+    Note over Pol,Aud: no global fall-through — out-of-scope is not a soft-pass
+    Aud-->>Eng: honest policies-evaluated list (three-state)
+```
+
+## What an engineer adds
+- The **profile resolver** (approved-list selection plus platform default) and the **by-construction policy
+  selection** that binds the profile to its policy set.
+- The **three-state outcome recording**, with out-of-scope emitted for non-member policies and no global
+  fall-through path. Where these gates sit in the build is unchanged.
+
+## Pointers
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `governance/policy-resolution-capability`.

--- a/docs/flows/uc-17-profile-resolution-capability.md
+++ b/docs/flows/uc-17-profile-resolution-capability.md
@@ -1,0 +1,52 @@
+# UC-17 · Profile resolution & atomic onboarding — the play
+
+**Purpose:** how DCM resolves the instance profile and onboards a tenant atomically, on top of
+[request-realization](request-realization.md) — only the UC-specific mechanics. Validation UC for **DR-B**.
+
+> **Use Case:** `cross-domain/profile-resolution-capability` · **Persona:** platform-engineer.
+
+## What's different in the engine
+- **Resolution reads the instance declaration.** The instance publishes an approved profile list and a
+  default. The resolver selects from that list; near-term the default applies instance-wide. Profiles are
+  capability sets — comparison is set-containment, not a rank.
+- **Onboarding runs as one transaction.** An orchestration-flow policy sequences the identity boundary,
+  profile binding (a `policy_profile` DCMGroup), quotas, and auth-provider claims mapping, and commits them
+  all-or-nothing. Any failed step rolls the whole onboarding back.
+- **The overlay is composed separately.** A compliance/sovereignty overlay is bound alongside the profile, not
+  merged into it, so it stays independently visible and auditable.
+- **One atomic record.** The successful onboarding is recorded as a single audit record, matching its
+  all-or-nothing nature.
+
+## Sequence — only the UC-specific part
+```mermaid
+sequenceDiagram
+    actor Eng as Platform engineer
+    participant Res as Profile resolver
+    participant Orch as Onboarding orchestration
+    participant Auth as Auth provider
+    participant St as Tenant store
+    participant Aud as Audit store
+
+    Eng->>Res: onboard tenant
+    Res->>Res: resolve profile from approved list + default
+    Res-->>Orch: resolved profile (+ compliance overlay, composed separately)
+    Orch->>St: identity boundary, policy_profile binding, quotas
+    Orch->>Auth: configure claims-mapping reference
+    alt every step succeeds
+        Orch->>St: commit all
+        Orch->>Aud: record atomic onboarding as one record
+        Aud-->>Eng: tenant bound to resolved profile
+    else any step fails
+        Orch->>St: roll back — nothing persists
+        Orch-->>Eng: onboarding failed, no partial tenant
+    end
+```
+
+## What an engineer adds
+- The **profile resolver** over the instance's approved-list + default, with **set-containment** comparison
+  (no ranking).
+- The **onboarding orchestration** that binds identity, profile, quotas, and auth claims atomically, and
+  **composes** the compliance overlay alongside the profile rather than folding it in.
+
+## Pointers
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `cross-domain/profile-resolution-capability`.

--- a/docs/flows/uc-18-vm-status-provenance.md
+++ b/docs/flows/uc-18-vm-status-provenance.md
@@ -1,0 +1,47 @@
+# UC-18 · Realized status with field-level provenance — the play
+
+**Purpose:** how DCM runs the post-commit half — ingesting the libvirt provider's status and stamping provenance on each realized field, then reconciling drift — on top of [request-realization](request-realization.md). Only the UC-specific mechanics here.
+
+> **Use Case:** `libvirt-vm-provider/standard/vm-status-provenance` · **Persona:** auditor.
+
+## What's different in the engine
+
+- **A reconcile path, not just a build path.** request-realization's dispatcher returns native facts once at commit. This case adds a **status reconciler** that keeps reading provider status and writing it back — on commit, on provider events, and on periodic sweeps.
+- **Provenance stamped at ingest.** Each field written to the realized record is paired with the **run id and timestamp** of the read that produced it. The state store already carries provenance for requested values; the reconciler extends it to realized values.
+- **Drift is a diff, then an attributed update.** A re-read is compared field-by-field to stored status. Changed fields are updated with the *new* run's provenance; unchanged fields keep their existing origin — no blanket overwrite.
+
+## Sequence — only the UC-specific part
+
+```mermaid
+sequenceDiagram
+    participant Disp as Dispatcher
+    participant Rec as Status reconciler
+    participant Lib as libvirt provider
+    participant St as State store
+
+    Disp->>Rec: committed VM, native id
+    Rec->>Lib: read status (state, host, ip, mac, disks)
+    Lib-->>Rec: current facts + provider run id
+    Rec->>St: write each field with run id and timestamp
+    Note over Rec,St: realized value and its provenance stored together
+    loop periodic reconcile or provider event
+        Rec->>Lib: re-read status
+        Lib-->>Rec: current facts
+        Rec->>Rec: diff against stored, field by field
+        alt a field changed (drift)
+            Rec->>St: update value and advance provenance to this run
+        else unchanged
+            Rec->>St: leave value and provenance as is
+        end
+    end
+```
+
+## What an engineer adds
+
+- **The provider's status mapping** — which libvirt facts map to `state`, `host`, `ip`, `mac`, and disk-path fields (`dcm-registration-spec.md`).
+- **The reconcile trigger** — how often to sweep and which provider events force a re-read; the diff-and-attribute logic itself is the engine's.
+
+## Pointers
+
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `libvirt-vm-provider/standard/vm-status-provenance`.
+- Four states (Realized side): udlm [`foundations/four-states.md`](https://github.com/croadfeldt/udlm/tree/main/docs/foundations/four-states.md).

--- a/docs/flows/uc-19-audit-merkle-tree-verification.md
+++ b/docs/flows/uc-19-audit-merkle-tree-verification.md
@@ -1,0 +1,46 @@
+# UC-19 · Cryptographic audit verification — the play
+
+**Purpose:** how DCM answers an auditor's tamper-evidence query — serving signed tree heads and inclusion/consistency proofs from the audit provider, with the signing key pinned in-boundary — on top of [request-realization](request-realization.md). Only the UC-specific mechanics.
+
+> **Use Case:** `governance/audit-merkle-tree-verification` · **Persona:** compliance-auditor.
+
+## What's different in the engine
+
+- **Placement routes to an audit/information provider, and the dispatcher never builds.** The reserve/commit pair is replaced by a **serve-proofs** call. The request reads audit state and returns evidence; no tenant resource is touched.
+- **A sovereignty gate on the key, before any signing.** The policy engine checks that the signing key material resides in-boundary; if not, the request is rejected before a tree head is produced.
+- **The proof set is the response body.** Tree heads (one per covered epoch), an inclusion proof per requested event, and consistency proofs across heads. The auditor verifies them independently — DCM produces, the auditor checks.
+- **Failures are located.** If the provider cannot prove an event, the response names the event and the proof step, so the auditor sees *what* failed, not just *that* it failed.
+
+## Sequence — only the UC-specific part
+
+```mermaid
+sequenceDiagram
+    actor Auditor
+    participant Pol as Policy engine
+    participant Aud as Audit provider
+    participant St as Audit event store
+
+    Auditor->>Pol: verify events [a..b]
+    Pol->>Pol: check signing-key residency in-boundary
+    alt key out of boundary
+        Pol-->>Auditor: rejected — residency violation
+    else key in-boundary
+        Pol->>Aud: request proofs for [a..b]
+        Aud->>St: look up events by handle and epoch
+        St-->>Aud: event records
+        Aud-->>Pol: signed tree heads, inclusion proofs, consistency proofs
+        Pol-->>Auditor: proof set
+        Auditor->>Auditor: verify independently against tree heads
+        Note over Auditor: any miss names the event and the proof step
+    end
+```
+
+## What an engineer adds
+
+- **The audit provider** — a transparency-log provider that maintains the Merkle tree over audit events and serves heads and proofs (single-signer v1).
+- **The residency policy** — the sovereign-profile rule pinning signing-key material in-boundary. The proof math and the verification contract are the provider's.
+
+## Pointers
+
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `governance/audit-merkle-tree-verification`.
+- Capability-validation sibling: [udlm uc-20-audit-chain-proofs-capability](https://github.com/croadfeldt/udlm/tree/main/docs/flows/uc-20-audit-chain-proofs-capability.md).

--- a/docs/flows/uc-20-audit-chain-proofs-capability.md
+++ b/docs/flows/uc-20-audit-chain-proofs-capability.md
@@ -1,0 +1,41 @@
+# UC-20 · Transparency-log capability validation — the play
+
+**Purpose:** how DCM demonstrates the DR-D transparency-log capability — a registered information provider selected by capability match, serving all three proof kinds with the signing key in-boundary — on top of [request-realization](request-realization.md). Only the UC-specific mechanics. The verification *act* is [UC-19](uc-19-audit-merkle-tree-verification.md)'s play; this validates the capability is *present*.
+
+> **Use Case:** `governance/audit-chain-proofs-capability` · **Persona:** compliance-auditor.
+
+## What's different in the engine
+
+- **Placement selects on an advertised capability.** The provider registry holds a provider that declares `transparency-log`; placement picks it for an audit-proof request the way it picks a VM provider for a VM — by capability, then policy.
+- **The capability contract is all three proof kinds.** DCM validates the selected provider returns **tree heads**, **inclusion proofs**, and **consistency proofs**. A provider serving only some does not satisfy DR-D.
+- **Sovereignty is a usability gate.** The in-boundary key policy runs as part of confirming the capability is usable under the sovereign profile — not a separate afterthought.
+- **Single-signer v1 recorded as the boundary.** No external-witness cross-check is attempted; the validation asserts what v1 covers and flags equivocation defense as follow-up.
+
+## Sequence — only the UC-specific part
+
+```mermaid
+sequenceDiagram
+    actor Auditor
+    participant Pol as Policy engine
+    participant Reg as Provider registry
+    participant Aud as Transparency-log provider
+
+    Auditor->>Pol: audit-proof request (capability transparency-log)
+    Pol->>Reg: which provider advertises transparency-log?
+    Reg-->>Pol: the information provider
+    Pol->>Pol: check signing-key residency in-boundary
+    Pol->>Aud: request tree heads, inclusion, consistency proofs
+    Aud-->>Pol: all three proof kinds, key in-boundary
+    Pol->>Pol: confirm all three present and residency held
+    Pol-->>Auditor: DR-D capability validated — single-signer v1
+```
+
+## What an engineer adds
+
+- **The transparency-log provider registration** — declaring the `transparency-log` capability and the three proof kinds it serves (`dcm-registration-spec.md`).
+- **The residency policy** — the sovereign-profile rule pinning the signing key. The proof generation and the single-signer boundary are the provider's.
+
+## Pointers
+
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `governance/audit-chain-proofs-capability`.
+- The verification act: [udlm uc-19-audit-merkle-tree-verification](https://github.com/croadfeldt/udlm/tree/main/docs/flows/uc-19-audit-merkle-tree-verification.md).

--- a/docs/flows/uc-21-solution-architecture-deployment.md
+++ b/docs/flows/uc-21-solution-architecture-deployment.md
@@ -1,0 +1,43 @@
+# UC-21 · Solution architecture deployment — the play
+
+**Purpose:** how DCM runs a whole solution — decomposing a code-first DSL into component requests, ordering them by dependency, and running each through [request-realization](request-realization.md), then assembling one wired receipt. Only the orchestration mechanics here; each component's own build is the base flow.
+
+> **Use Case:** `cross-domain/solution-architecture-deployment` · **Persona:** solution-architect.
+
+## What's different in the engine
+
+- **An orchestrator wraps the dispatcher.** request-realization drives one resource end-to-end. This case adds a **solution orchestrator** that decomposes the DSL, builds the dependency graph, and calls request-realization once per component — in topological order.
+- **References gate ordering.** A component's request isn't assembled until its upstreams have committed and produced the outputs it consumes (a database endpoint, a subnet id). The orchestrator holds a dependent until its inputs resolve — the wiring drives the schedule.
+- **Providers vary per component, and that's fine.** Each component places independently; the app tier may land on OpenShift while the database lands elsewhere. The orchestrator doesn't force one provider.
+- **The receipt records the wiring.** On completion the orchestrator writes one realized receipt: every component's realized state plus the cross-component references — which output fed which input — not N disconnected records.
+
+## Sequence — only the UC-specific part
+
+```mermaid
+sequenceDiagram
+    actor Architect
+    participant Orch as Solution orchestrator
+    participant RR as request-realization (per component)
+    participant St as State store
+
+    Architect->>Orch: solution architecture (code-first DSL)
+    Orch->>Orch: decompose into components + dependency graph
+    Orch->>Orch: order topologically (deps first)
+    loop each component in order
+        Orch->>RR: realize component (assemble, place, enrich, reserve, commit)
+        RR-->>Orch: realized component + outputs
+        Orch->>Orch: feed outputs to dependents that consume them
+    end
+    Orch->>St: write receipt — all components + cross-component references
+    Orch-->>Architect: solution deployed
+```
+
+## What an engineer adds
+
+- **The decomposition** — how the DSL maps to typed component requests and dependency edges, and each component's base engineering pattern.
+- **Nothing about single-component realization** — assemble, place, enrich, reserve, commit are request-realization's; the orchestrator only sequences them and records the wiring.
+
+## Pointers
+
+- Stage: [udlm request-realization](https://github.com/croadfeldt/udlm/tree/main/docs/flows/request-realization.md). UC source: `cross-domain/solution-architecture-deployment`.
+- Four states (per component): udlm [`foundations/four-states.md`](https://github.com/croadfeldt/udlm/tree/main/docs/foundations/four-states.md).


### PR DESCRIPTION
Publishes the **21 September-release use cases** (DAV set 29, *FF Extended Target*) as flows to the downstream repo, stacked on the request-realization flow PR.

Each UC is a **lighter** flow that builds on request-realization — references the shared machinery and documents only what the case adds. Labeled by Use Case number.

**by-persona.md** is the usage-by-role index: application-team-member (5), platform-operator (5), platform-engineer (7), compliance-auditor/auditor (3), solution-architect (1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
