### PR TITLE
[DCM-01] Root docs — README, overview, license, top-level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+docs/internal/
+
+# macOS noise
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,112 @@
+# AGENTS.md — DCM
+
+> Cross-agent context file ([agents.md](https://agents.md) standard). `CLAUDE.md` is a symlink to this
+> file so Claude Code reads the same source of truth. Keep this current as the architecture evolves.
+
+## What this repo is
+
+**DCM — Data Center Management.** A vendor-neutral architecture specification for an intent-driven
+control plane that provisions, governs, and rehydrates data-center resources. **DCM is one realization
+of UDLM** (the Unified Data-center Lifecycle Model, `github.com/croadfeldt/udlm`) — understand the UDLM
+substrate first; DCM is the control-plane architecture built on it.
+
+**This is a docs/architecture-only repo — there is no application code** (no Go/Python/TS, no build).
+The deliverable is the specification: Markdown architecture docs, machine-readable contracts (OpenAPI /
+JSON Schema / SQL), ADRs, and a taxonomy. **Apache-2.0.**
+
+## Layout
+
+```
+architecture/      Core architecture. ADRs (adr/ + README index), DCM-Capabilities-Matrix.md, and subsystem folders
+                   (control-plane/, convergence-engine/, ingestion/, credentials-and-auth/,
+                   governance-enforcement/, runtime-features/, topology/, persistence/, integrations/).
+                   Entry docs: overview.md, layering.md, operator-perspective.md, design-principles.md.
+docs/              Prose specifications/ (consumer-api-spec, dcm-admin-api-spec), engineering/
+                   (ENGINEERING-ALIGNMENT.md), holistic-vision.md.
+schemas/           Machine-readable contracts: openapi/ (consumer/admin/provider-callback/operator),
+                   jsonschema/ (events, providers, entities, policies, resource-type template),
+                   sql/001-initial.sql (18 tables).
+reference/         implementation-standards.md, implementation-specifications.md, operational-reference.md.
+taxonomy/          DCM-Taxonomy.md (the controlled vocabulary).
+examples/          orchestration-scenarios.md. (Full examples live in the external dcm-project/dcm-examples repo.)
+dav/               The DCM validation corpus/schemas DAV runs against (see croadfeldt/dav).
+README.md, project-overview.md, LICENSE
+```
+
+## Read first (entry points)
+
+1. UDLM substrate — `github.com/croadfeldt/udlm` (DCM is one realization of it).
+2. `architecture/overview.md` → `architecture/layering.md` (the UDLM/DCM boundary).
+3. `architecture/convergence-engine/overview.md` — the intent→realized loop, the heart of DCM.
+4. `architecture/operator-perspective.md`, `taxonomy/DCM-Taxonomy.md`.
+5. `architecture/DCM-Capabilities-Matrix.md` — what DCM can do.
+6. `architecture/adr/README.md` + ADRs 001–016 — the decision history (the "why").
+
+## Operating rules
+
+- **Commits:** `--no-gpg-sign`, author = the repo owner's public git identity (match `git log -1 --format='%an <%ae>'`), trailer
+  `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. Commit subjects use a lowercase
+  `scope: short description` prefix (`sov:`, `use-cases:`, `docs:`, `observability:`, …) where scope =
+  the doc area touched.
+- **PRs are subject-scoped** — one logical doc area per PR (≤2–3k lines; split larger subjects on logical
+  boundaries). **Lead with the "why"** and capture decisions as **ADRs** in `architecture/adr/` (next
+  number, one decision each) — that is this repo's document-the-why mechanism.
+- **Remotes:** GitHub `croadfeldt/dcm` (origin) + `dcm-project/dcm` (upstream — the canonical project
+  home; promote scoped PRs upstream). Default branch `main`; use `gh`.
+- **Counts come from source artifacts, never summary blocks.** Summary blocks in this repo (e.g. README
+  "Key Facts", the old onboarding doc) disagree with each other and with the actual files. When you need a
+  number, read the artifact:
+  - capabilities → `architecture/DCM-Capabilities-Matrix.md` total (311 across 39 domains)
+  - SQL tables → `schemas/sql/001-initial.sql` (18)
+  - events → the §65 Event Catalog / UDLM event-catalog (82 across 26 domains)
+  - API paths → `schemas/openapi/dcm-consumer-api.yaml` (75) / `dcm-admin-api.yaml` (admin spec)
+  - providers → declared **capabilities** `(verb × domain)`, not fixed types (ADR-PROV-002); the legacy "provider types" are convenience labels for capability profiles — see `croadfeldt/udlm` capability-discovery.md
+  - policy types → 7, with 2 evaluation modes (Internal via OPA / External via provider)
+
+## Terminology decisions (locked 2026-06-30)
+
+These decisions are settled. Apply them in all documentation and use case authoring.
+
+### Provider hierarchy
+
+**Provider** is the generic interface — any external component that provides capabilities to DCM.
+**Service provider** is one typed provider within that hierarchy (not the top-level name).
+Other provider types include: information, credential, auth, peer_dcm, process, etc.
+Each provider registers with the generic provider interface and declares its capabilities.
+Do NOT use "resource provider" — that rename was proposed but reversed.
+
+> **Refined by ADR-PROV-002 (2026-07-11):** a provider is **not a type** — it declares **capabilities**
+> `(verb × domain)` and occupies non-exclusive **capability categories**; the "typed provider" names above
+> are convenience labels for capability profiles, and policy targets a capability/category, never a provider
+> type. See `croadfeldt/udlm` `capability-discovery.md` + ADR-PROV-002/003/004 + ADR-RBAC-001.
+
+### Validation policy (merged)
+
+**Gating Policy has been merged into Validation Policy.** There is no longer a separate "Gating Policy"
+type. Validation Policy now carries two orthogonal properties:
+- `enforcement_class`: `compliance` (boolean deny — halts request) or `operational` (contributes risk score)
+- `output_class`: `structural` (boolean pass/fail) or `advisory` (warnings without blocking)
+
+A validation policy with `enforcement_class: compliance` is what was previously called a "gating policy."
+Do NOT use "gatekeeper policy" (OPA Gatekeeper collision) or "gating policy" as a standalone type.
+
+### Composite service / resource
+
+**Composite service** is DCM's native concept for multi-component architectural patterns.
+Do NOT use "likeC4" as a DCM-native concept — likeC4 is a customer-specific format (PNC).
+A *process provider* can convert likeC4 → composite service, but DCM does not natively speak
+any customer-specific format. UDLM is the core design language; customer format converters
+live outside the core.
+
+### Realized (not fulfilled)
+
+The lifecycle state where a resource exists and is provider-confirmed is called **Realized**.
+Do NOT use "fulfilled."
+
+## Exploring the architecture
+
+Read the specs directly — the **Layout** and **Read first** sections above route you, and each concern has
+one authoritative doc. The former `architecture/ai/DCM-AI-PROMPT.md` (a 5,950-line full-architecture
+snapshot) was **retired**: it duplicated the specs and drifted stale — it still taught the pre-ADR-PROV-002
+typed-provider model, among other things. Load the specific spec docs you need into context; nothing an
+agent needs is more than one hop away via the map above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to DCM
+
+DCM — the Data Center Management control plane — is open-source under Apache License 2.0. Contributions
+to the control plane, the provider ecosystem, and the architecture docs are welcome. The architecture is
+captured in `architecture/`; the major decisions are recorded as ADRs in `architecture/adr/`.
+
+## Subject-scoped pull requests (default)
+
+The default unit of contribution is **one subject per PR** — a single, complete logical change, titled
+by its subject (e.g. "Enable cost provider", "Adopt FOCUS 1.4 for cost", "Add EgressFirewall to the
+namespace"). Keep PRs to roughly ≤2–3k lines; if a subject is larger, split it along logical boundaries
+into a sequence of independently reviewable, subject-scoped PRs rather than forcing one oversized change.
+Prefer logical boundaries over size-driven cuts, and never bundle unrelated subjects. Lead every PR
+description with a short **Why** (the rationale), linking the ADR or requirement when one exists.
+
+## Document the why
+
+Every non-trivial change records its rationale, not just its diff:
+- **Architectural decisions** get an ADR in `architecture/adr/` (next available number; follow the
+  existing shape — Context, Decision, Alternatives Considered, Consequences). One decision per ADR;
+  don't bundle.
+- **Requirement changes** update the relevant requirement set (`dcm-platform-requirements.md` and the
+  ID series — `ADS-`, `AUD-`, `RDG-`, …).
+- A reviewer should be able to reconstruct *why* a change exists from the repo, not just *what* changed.
+
+### Writing standard — concise, clear, contextual, complete as minimally needed
+
+The default for every ADR and document. Cold-reader-openable and *less is more* are one standard,
+reconciled by **orienting, not re-teaching**: point to where foundational context lives, then stay
+on the decision.
+
+- **Background belongs in foundational documents, referenced — not inlined.** A definition or prior
+  decision a reader needs lives in its home doc; this one links to it with a one-line gist and does
+  not reproduce it. Open every document with an on-ramp — a **"Background — read first"** block
+  (ADRs) or a *read-first* pointer (other docs): the foundational reading a third party needs, each
+  cited once with what it settles, labeled so a reader who has the context skips it.
+- **Complete as *minimally* needed.** Include exactly what moves the decision or task; cut the rest —
+  including a point another section already made, and rhetorical flourish. Precision is never cut.
+- **Know what the document *is* (Diátaxis).** Explanation (an ADR — *why*), reference (a
+  schema/spec — *what*), how-to, or tutorial. Don't blend modes — an ADR *points to* the schema, it
+  doesn't reproduce it; mode-blending is the main source of bloat.
+- **References carry their gist** — never a bare number; one line on what it settled.
+- Decision records are **immutable once Accepted** — superseded, not edited.
+
+This mirrors the UDLM authoring standard (`CONTRIBUTING.md` DOC-001) so the two repos read the same.
+
+## Licensing
+
+By contributing to DCM you agree your contributions are licensed under Apache License 2.0, matching the
+project license.

--- a/LICENSE
+++ b/LICENSE
@@ -174,28 +174,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,40 +1,122 @@
-# DCM
+# DCM — Data Center Management
 
-DCM (Data Center Management) is envisioned as a framework designed to provide a "hyperscaler-like cloud experience" for on-premises infrastructure. It aims to centralize and automate the management, observation, and lifecycle of IT/IS services within an enterprise data center. This is a work in progress with the initial stage of HLD documentation completed. Detailed specifications and discussions are on-going. Expertise and opinions are encouraged and welcome.
-  
-## Core Principles & Goals:
-  
-* **Centralized Management**: Consolidate disparate automation efforts under a single control plane or "single pane of glass" to manage various data center components.
-* **Automation & Self-Service**: Leverage existing automation tools (like Ansible Automation Platform) to offer a self-service model for provisioning, configuration, and day-to-day management. The goal is to enable application teams to define and deploy infrastructure as code.
-* **Declarative Infrastructure**: Define the desired state of infrastructure, with the system working to achieve and maintain that state, aiding in reconciliation between discovered and intended inventory.
-* **Composability**: Emphasize a composable architecture that allows for reusable services and operational efficiencies.
-* **Technology Agnostic Framework**: Designed to be flexible and consume common data formats, translating them to appropriate technologies, though an opinionated model is available.
-* **Full Lifecycle Management**: Enable complete lifecycle management of IT/IS services and ephemeral/declarative infrastructure.
-* **Mimics Kubernetes Design**: Draws inspiration from Kubernetes' orchestration and declarative control plane.
-* **API First**: All integrations are done via a common API framework.
-* **AI Ready**: DCM is standalone, but designed with AI in mind as core components and AIOps layered over the top.
-  
-## Status of next release (alpha)
-  
-- [ ] todo 1 (owned by ....)
-- [ ] todo 2 (owned by ....)
-- [ ] todo 3 (owned by ....)
-- [ ] todo 4 (owned by ....)
-  
-## Recommended Reading
-- [overview.md](overview.md) - Project overview - will be merged into READMe.
-- [taxonomy.md](./taxonomy/) — DCM taxonomy and definitions
+DCM is a framework for sovereign private cloud management. It provides a
+declarative control plane for managing the lifecycle of arbitrary infrastructure
+resources across an enterprise — from bare metal and VMs to containers,
+applications, and managed services.
 
-## AI Model Knowledge Base
+**DCM is one realization of [UDLM](https://github.com/croadfeldt/udlm)**, the
+Universal Data Lifecycle Model. UDLM is the wire-compatible substrate
+(entity types, four-state lifecycle, contracts, identifiers, events). DCM is
+the operational platform built on it — convergence engine, control-plane
+components, deployment topology, persistence, runtime features, governance
+enforcement, credentials, and integrations.
 
-[Infrastructure Knowledge YAML file](architecture/infrastructure_knowledge.yaml) - This file is pre-loaded with information and context on DCM to be used by an AI model. - This is a WIP in progress, best effort to be update with changes.
-  
-## MVP
-_(No text files listed)_
-  
-## Other projects in the same space
-There are many other projects in the same space, like:
-  
-* [Crossplane](https://crossplane.io)
-* [Kessel](https://github.com/project-kessel)
-* [KRO](https://kro.run)
+**Three foundational abstractions:** Data · Provider · Policy
+**License:** Apache 2.0
+
+---
+
+## Repository Structure
+
+```
+dcm/
+├── architecture/
+│   ├── overview.md                        ← Start here — DCM architecture entry point
+│   ├── layering.md                        ← UDLM/DCM boundary and how they relate
+│   ├── operator-perspective.md            ← Narrative operator/implementer handbook
+│   ├── design-principles.md               ← DCM-specific implementation choices
+│   ├── 00-split-manifest.md               ← Permanent record of the UDLM/DCM split
+│   ├── 00-layering-data-model-vs-dcm.md   ← Superseded stub — see layering.md
+│   ├── control-plane/                     ← Components, self-health, internal auth,
+│   │                                        session revocation, API versioning
+│   ├── convergence-engine/                ← The intent→realized loop:
+│   │                                        overview, policy evaluation (matrix
+│   │                                        evaluator), scoring, recovery/retry,
+│   │                                        dependency orchestration
+│   ├── ingestion/                         ← Brownfield ingestion engine + workload analysis
+│   ├── credentials-and-auth/              ← Auth implementation, credentials,
+│   │                                        provider callback mechanism (mTLS + cred),
+│   │                                        authority enforcement
+│   ├── governance-enforcement/            ← Accreditation monitor, registry
+│   │                                        enforcement, contribution pipeline,
+│   │                                        policy profiles
+│   ├── runtime-features/                  ← Scheduling, notifications, webhooks/
+│   │                                        messaging, federation runtime,
+│   │                                        deployment redundancy
+│   ├── topology/                          ← DCM's canonical 9-layer location
+│   │                                        hierarchy + placement/priority bands
+│   ├── persistence/                       ← PostgreSQL mandate + implementation
+│   ├── integrations/                      ← ITSM, Kessel evaluation
+│   ├── adr/                               ← Architectural Decision Records
+│   ├── DCM-Capabilities-Matrix.md
+│   ├── DISCUSSION-TOPICS.md
+├── examples/
+│   └── orchestration-scenarios.md         ← DCM-specific orchestration (builds on
+│                                            UDLM canonical examples)
+├── reference/
+│   ├── implementation-standards.md        ← Specific algorithms, libs, configs DCM uses
+│   ├── implementation-specifications.md
+│   └── operational-reference.md
+├── docs/                                  ← Index: docs/README.md
+│   ├── specifications/                    ← Prose specification documents
+│   ├── flows/                             ← Stage/play flow docs (request-realization, by-persona)
+│   ├── how-to/                            ← How-to guides (profiles, migration/rehydration)
+│   └── engineering/                       ← Engineering alignment + reconciliation
+├── taxonomy/DCM-Taxonomy.md
+├── schemas/                               ← OpenAPI, JSON Schema, SQL
+├── dav/                                   ← validation/assessment testbed (non-normative consumer)
+├── project-overview.md
+├── LICENSE
+└── README.md
+```
+
+For the substrate (entity types, four states, wire contracts, identifiers,
+events, schema sharing, conformance), see
+**[github.com/croadfeldt/udlm](https://github.com/croadfeldt/udlm)**.
+
+## Key Facts
+
+| Metric | Value |
+|--------|-------|
+| Architecture documents | 58 data model + 15 specifications |
+| Capabilities | 322 across 39 domains |
+| Provider types | 6 (service, information, meta, auth, peer_dcm, process) |
+| Policy evaluation modes | 2 (Internal via OPA, External via provider) |
+| Control plane services | 9 |
+| Required infrastructure | 1 (PostgreSQL-compatible DB) — auth, secrets, events handled internally |
+| Consumer API | 74 paths |
+| Admin API | 61 paths |
+| Event catalog | 101 payloads across 22 domains |
+
+## Getting Started
+
+1. **Understand the substrate first** — read [UDLM's README and CONFORMANCE.md](https://github.com/croadfeldt/udlm). DCM only makes sense if you know what it's a realization of.
+2. **Read DCM's architecture overview** — [`architecture/overview.md`](architecture/overview.md), then [`architecture/layering.md`](architecture/layering.md) for the UDLM/DCM boundary.
+3. **Read the operator perspective** — [`architecture/operator-perspective.md`](architecture/operator-perspective.md) — narrative handbook for running DCM.
+4. **Dive into the convergence engine** — [`architecture/convergence-engine/overview.md`](architecture/convergence-engine/overview.md) — the heart of DCM.
+5. **Learn the vocabulary** — read [`taxonomy/DCM-Taxonomy.md`](taxonomy/DCM-Taxonomy.md).
+6. **See what DCM can do** — browse [`architecture/DCM-Capabilities-Matrix.md`](architecture/DCM-Capabilities-Matrix.md).
+7. **Build a service** — start with the OpenAPI specs in [`schemas/openapi/`](schemas/openapi/) and the engineering guide in [`docs/engineering/ENGINEERING-ALIGNMENT.md`](docs/engineering/ENGINEERING-ALIGNMENT.md).
+8. **Deploy an example** — see [dcm-examples](https://github.com/dcm-project/dcm-examples).
+
+## Related Repositories
+
+| Repository | Purpose |
+|-----------|---------|
+| [control-plane](https://github.com/dcm-project/control-plane) | The DCM control plane — runtime source for the catalog, placement, policy, and service-provider domains in a single process |
+| [cli](https://github.com/dcm-project/cli) | `dcm` command-line client (catalog, policy, provider operations) |
+| [kubevirt-service-provider](https://github.com/dcm-project/kubevirt-service-provider) | Service provider — VMs via KubeVirt/CNV |
+| [k8s-container-service-provider](https://github.com/dcm-project/k8s-container-service-provider) | Service provider — containers via Kubernetes Deployments/Services |
+| [acm-cluster-service-provider](https://github.com/dcm-project/acm-cluster-service-provider) | Service provider — OpenShift clusters via ACM/HyperShift |
+| [dcm-examples](https://github.com/dcm-project/dcm-examples) | Reference implementations — Summit demo with Go services, Ansible, OpenShift manifests |
+| [dcm-project.github.io](https://github.com/dcm-project/dcm-project.github.io) | Project website — documentation segmented by domain |
+| [enhancements](https://github.com/dcm-project/enhancements) | Design proposals |
+| [shared-workflows](https://github.com/dcm-project/shared-workflows) | CI/CD workflows |
+
+> **Runtime topology note.** The catalog, placement, policy, and service-provider domains were originally separate
+> services (`catalog-manager`, `placement-manager`, `policy-manager`, `service-provider-manager`, `api-gateway`).
+> They were consolidated into the single **control-plane** process in May 2026 — they now call each other in-process
+> on the provisioning path rather than over HTTP — and those five repositories are archived. The architecture docs
+> in this repository describe the logical decomposition (the control plane's internal services); the table above
+> lists the repositories that hold the current runtime.


### PR DESCRIPTION
**Republished from croadfeldt/dcm** (source of truth). Part of the ordered redistribution — see dcm-project/dcm#108. Adds/updates croadfeldt content; downstream-only files untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)